### PR TITLE
[Bugfix] Support N-dimensional tensors in pack_to_int32 and unpack_from_int32

### DIFF
--- a/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
@@ -161,7 +161,7 @@ class PackedQuantizationCompressor(BaseQuantizationCompressor):
             assert (
                 zero_point is not None
             ), "Asymmetric quantization requires zero-point values"
-            original_zp_shape = (original_shape[0], scale.shape[-1])
+            original_zp_shape = (*original_shape[:-1], scale.shape[-1])
             zero_point = unpack_from_int32(
                 zero_point, num_bits, original_zp_shape, packed_dim=0
             )
@@ -209,6 +209,15 @@ def pack_to_int32(
 
     if num_bits < 1:
         raise ValueError(f"num_bits must be at least 1, got {num_bits}")
+
+    # Handle N-dimensional tensors (e.g. MoE 3D weights) by packing each 2D slice
+    if value.ndim > 2:
+        return torch.stack(
+            [
+                pack_to_int32(value[i], num_bits, packed_dim)
+                for i in range(value.shape[0])
+            ]
+        )
 
     # Convert to unsigned range for packing, matching quantization offset
     offset = 1 << (num_bits - 1)
@@ -264,6 +273,15 @@ def unpack_from_int32(
 
     if num_bits > 8:
         raise ValueError("Unpacking is only supported for less than 8 bits")
+
+    # Handle N-dimensional tensors (e.g. MoE 3D weights) by unpacking each 2D slice
+    if value.ndim > 2:
+        return torch.stack(
+            [
+                unpack_from_int32(value[i], num_bits, shape[1:], packed_dim)
+                for i in range(value.shape[0])
+            ]
+        )
 
     pack_factor = 32 // num_bits
 

--- a/tests/test_compressors/quantized_compressors/test_pack_quant.py
+++ b/tests/test_compressors/quantized_compressors/test_pack_quant.py
@@ -551,3 +551,25 @@ def test_zero_point_pack_unpack_consistency(num_bits, strategy):
 
     assert torch.equal(original_zp, unpacked_zp)
     assert unpacked_zp.dtype == torch.int8
+
+
+def test_pack_unpack_3d_round_trip():
+    """3D tensors (e.g. MoE expert weights) should pack/unpack correctly."""
+    num_bits = 4
+    shape = (4, 8, 32)  # (num_experts, rows, cols)
+    value = torch.randint(-8, 7, shape, dtype=torch.int8)
+    packed = pack_to_int32(value, num_bits)
+    unpacked = unpack_from_int32(packed, num_bits, torch.Size(shape))
+    assert torch.equal(value, unpacked)
+
+
+def test_pack_unpack_3d_matches_stacked_2d():
+    """3D pack/unpack should match stacking individual 2D results."""
+    num_bits = 4
+    shape = (4, 8, 32)
+    value = torch.randint(-8, 7, shape, dtype=torch.int8)
+    packed_3d = pack_to_int32(value, num_bits)
+    packed_2d = torch.stack(
+        [pack_to_int32(value[i], num_bits) for i in range(value.shape[0])]
+    )
+    assert torch.equal(packed_3d, packed_2d)


### PR DESCRIPTION
## Summary

Fixes #608.

## Problem

`pack_to_int32()` and `unpack_from_int32()` crash on 3D MoE expert weights `(num_experts, rows, cols)` because they hardcode `rows, cols = value.shape`. Similarly, `decompress_weight()` hardcodes `original_zp_shape` as 2D.

## Fix

Three changes in `pack_quantized.py`:

1. `pack_to_int32`: recurse over dim 0 when `ndim > 2`, packing each 2D slice independently
2. `unpack_from_int32`: same approach for unpacking
3. `decompress_weight`: generalize `original_zp_shape` to N-D with `(*original_shape[:-1], scale.shape[-1])`

2D tensors take the existing code path unchanged.

## Testing

- Unit tested: 2D round-trip, 3D round-trip, 3D vs stacked 2D, packed_dim=0, non-divisible cols (padding)
- End-to-end: Granite 4.0-h-small W4A16 GPTQ, 248 tensors packed successfully

## Context

Found while fixing Granite 4.0 W4A16 quantization (vllm-project/llm-compressor#2338). This is the third bug in the chain, after the `to_3d_expert()` shape fix (llm-compressor PR #2425) and the FX tracing fix (llm-compressor PR #2426).