### PR TITLE
[QuantizationMetadata] update for missing qparams and module attributes

### DIFF
--- a/src/compressed_tensors/quantization/quant_metadata.py
+++ b/src/compressed_tensors/quantization/quant_metadata.py
@@ -35,7 +35,6 @@ class QuantizationMetadata:
                 for suffix in (
                     "global_scale",
                     "scale",
-                    "shape",
                     "zero_point",
                     "g_idx",
                 )

--- a/src/compressed_tensors/quantization/quant_metadata.py
+++ b/src/compressed_tensors/quantization/quant_metadata.py
@@ -61,8 +61,6 @@ class QuantizationMetadata:
         Artifacts include any qparams, quantization_scheme, or wrapped
         forward method that might have been altered previously in lifecycle.
 
-        `quantization_status` and `quantization_enabled` are left unchanged.
-
         :param module: Module to clear
         """
         with unwrap_offload_forward(module):

--- a/src/compressed_tensors/quantization/quant_metadata.py
+++ b/src/compressed_tensors/quantization/quant_metadata.py
@@ -26,16 +26,21 @@ class QuantizationMetadata:
         All quantization parameter names that might be registered
         onto a module during lifecycle (excluding serialized parameters)
         """
-        return [KVCacheScaleType.KEY.value, KVCacheScaleType.VALUE.value] + [
-            f"{base_name}_{suffix}"
-            for base_name in ("input", "weight", "output")
-            for suffix in (
-                "global_scale",
-                "scale",
-                "zero_point",
-                "g_idx",
-            )
-        ]
+        return (
+            [KVCacheScaleType.KEY.value, KVCacheScaleType.VALUE.value]
+            + ["weight_shape", "weight_packed"]
+            + [
+                f"{base_name}_{suffix}"
+                for base_name in ("input", "weight", "output")
+                for suffix in (
+                    "global_scale",
+                    "scale",
+                    "shape",
+                    "zero_point",
+                    "g_idx",
+                )
+            ]
+        )
 
     @classmethod
     def clear_all_qparams(cls, module: Module):
@@ -72,3 +77,11 @@ class QuantizationMetadata:
             # Clear quantization_scheme
             if hasattr(module, "quantization_scheme"):
                 delattr(module, "quantization_scheme")
+
+            # Clear quantization_status
+            if hasattr(module, "quantization_status"):
+                delattr(module, "quantization_status")
+
+            # Clear quantization_enabled
+            if hasattr(module, "quantization_enabled"):
+                delattr(module, "quantization_enabled")


### PR DESCRIPTION
Add some missing qparams and attributes (quantization_status, quantization_enabled) to QuantizationMetadata which were previously missing, so they weren't being pruned correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quantization metadata now includes weight dimensions and packed-state info so all relevant parameter details are tracked.
  * Clearing quantization now fully removes quantization status flags and related configuration, preventing leftover state and ensuring modules behave cleanly after disabling quantization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->