### PR TITLE
Add MixFP4 compressed tensor format

### DIFF
--- a/src/compressed_tensors/compressors/__init__.py
+++ b/src/compressed_tensors/compressors/__init__.py
@@ -7,6 +7,7 @@ from .base import *
 
 # New per-format directories
 from .dense import *
+from .mixfp4 import *
 from .model_compressors import *
 from .mxfp4 import *
 from .mxfp8 import *

--- a/src/compressed_tensors/compressors/format.py
+++ b/src/compressed_tensors/compressors/format.py
@@ -18,6 +18,7 @@ __all__ = ["infer_model_format", "infer_module_format"]
 COMPRESSION_FORMAT_PRIORITY: List[CompressionFormat] = [
     CompressionFormat.mxfp4_pack_quantized,
     CompressionFormat.mxfp8_quantized,
+    CompressionFormat.mixfp4_pack_quantized,
     CompressionFormat.nvfp4_pack_quantized,
     CompressionFormat.pack_quantized,
     CompressionFormat.int_quantized,

--- a/src/compressed_tensors/compressors/mixfp4/__init__.py
+++ b/src/compressed_tensors/compressors/mixfp4/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# flake8: noqa
+
+from .base import *

--- a/src/compressed_tensors/compressors/mixfp4/__init__.py
+++ b/src/compressed_tensors/compressors/mixfp4/__init__.py
@@ -4,3 +4,4 @@
 # flake8: noqa
 
 from .base import *
+from .helpers import *

--- a/src/compressed_tensors/compressors/mixfp4/base.py
+++ b/src/compressed_tensors/compressors/mixfp4/base.py
@@ -58,8 +58,12 @@ class MixFP4PackedCompressor(BaseCompressor):
 
     @classmethod
     def _decompress_scale(cls, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
-        """Cast stored scales to the requested dense validation dtype."""
-        return scale.to(dtype)
+        """Decode stored scale magnitudes without interpreting flags as signs."""
+        if scale.dtype != torch.float8_e4m3fn:
+            raise ValueError("MixFP4 decompression expects float8_e4m3fn weight_scale")
+        raw = scale.contiguous().view(torch.uint8)
+        magnitude = (raw & 0x7F).view(torch.float8_e4m3fn)
+        return magnitude.to(dtype)
 
     @classmethod
     def _validate_scheme(cls, scheme: QuantizationScheme) -> QuantizationArgs:
@@ -80,6 +84,10 @@ class MixFP4PackedCompressor(BaseCompressor):
     ) -> TensorStateDict:
         """Pack dense weights while preserving flags in ``weight_scale``."""
         state_dict = state_dict.copy()
+        if "weight" not in state_dict:
+            raise ValueError("MixFP4 compression requires weight")
+        if "weight_scale" not in state_dict:
+            raise ValueError("MixFP4 compression requires weight_scale")
         weight = state_dict.pop("weight")
         scale = state_dict.pop("weight_scale")
         global_scale = state_dict.get("weight_global_scale", None)

--- a/src/compressed_tensors/compressors/mixfp4/base.py
+++ b/src/compressed_tensors/compressors/mixfp4/base.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Packed compressor for MixFP4 weight-only quantization.
+
+MixFP4 keeps the NVFP4 W4A16 tensor layout but uses the redundant sign bit of
+per-group float8_e4m3fn scales as a block-format flag: 0 selects FP4 E2M1 and
+1 selects signed INT4. No extra persistent side metadata is introduced.
+"""
+
+import torch
+from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.nvfp4.helpers import FLOAT_TO_E2M1
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+    QuantizationType,
+)
+from compressed_tensors.utils import TensorStateDict
+
+
+__all__ = [
+    "MixFP4PackedCompressor",
+    "pack_mixfp4_to_uint8",
+    "unpack_mixfp4_from_uint8",
+]
+
+
+_E2M1_CODEBOOK = torch.tensor(FLOAT_TO_E2M1, dtype=torch.float32)
+_FP4_MAX = 6.0
+_INT4_MAX = 7
+_FP8_FLAG_BIT = 0x80
+_MIXFP4_FORMATS = {
+    CompressionFormat.mixfp4_pack_quantized.value,
+    "mixed-fp4-int4-pack-quantized",
+}
+_MIXFP4_OBSERVERS = {"mixfp4", "mixed_fp4_int4"}
+
+
+@BaseCompressor.register(
+    name=CompressionFormat.mixfp4_pack_quantized.value,
+    alias="mixed-fp4-int4-pack-quantized",
+)
+class MixFP4PackedCompressor(BaseCompressor):
+    """
+    Compressor for MixFP4 quantized models.
+
+    The observer chooses FP4 or INT4 per 16-element block and stores that choice
+    in the sign bit of ``weight_scale``. This compressor preserves the scale
+    tensor as the only flag carrier and emits one packed 4-bit code per weight.
+    """
+
+    @classmethod
+    def _compress_scale(
+        cls, scale: torch.Tensor, weights: QuantizationArgs
+    ) -> torch.Tensor:
+        scale_dtype = weights.scale_dtype or torch.float8_e4m3fn
+        return scale.to(scale_dtype)
+
+    @classmethod
+    def _decompress_scale(cls, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        return scale.to(dtype)
+
+    @classmethod
+    def _validate_scheme(cls, scheme: QuantizationScheme) -> QuantizationArgs:
+        weights = scheme.weights
+        if weights is None:
+            raise ValueError("MixFP4 compression requires weight quantization args")
+        if not cls._is_mixfp4_weight_args(weights):
+            raise ValueError(
+                "MixFP4 requires symmetric TENSOR_GROUP float4 weights with "
+                "group_size=16 and float8_e4m3fn scales"
+            )
+        return weights
+
+    @classmethod
+    def compress(
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+    ) -> TensorStateDict:
+        state_dict = state_dict.copy()
+        weight = state_dict.pop("weight")
+        scale = state_dict.pop("weight_scale")
+        global_scale = state_dict.get("weight_global_scale", None)
+        weights = cls._validate_scheme(scheme)
+
+        if global_scale is None:
+            raise ValueError("MixFP4 compression requires weight_global_scale")
+
+        state_dict["weight_packed"] = pack_mixfp4_to_uint8(
+            weight=weight,
+            scale=scale,
+            global_scale=global_scale,
+            group_size=weights.group_size,
+        )
+        state_dict["weight_scale"] = cls._compress_scale(scale, weights)
+        state_dict = cls._remove_symmetric_zp(state_dict, scheme)
+        return state_dict
+
+    @classmethod
+    def decompress(
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+    ) -> TensorStateDict:
+        state_dict = state_dict.copy()
+        packed = state_dict.pop("weight_packed")
+        scale = state_dict.get("weight_scale")
+        global_scale = state_dict.get("weight_global_scale", None)
+        weights = cls._validate_scheme(scheme)
+
+        if scale is None or global_scale is None:
+            raise ValueError(
+                "MixFP4 decompression requires weight_scale and global_scale"
+            )
+
+        scale_float = cls._decompress_scale(scale, torch.bfloat16)
+        state_dict["weight"] = unpack_mixfp4_from_uint8(
+            weight_packed=packed,
+            scale=scale,
+            global_scale=global_scale,
+            group_size=weights.group_size,
+            dtype=torch.bfloat16,
+        )
+        state_dict["weight_scale"] = torch.nn.Parameter(
+            scale_float, requires_grad=False
+        )
+        return state_dict
+
+    @classmethod
+    def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
+        """Match only explicit MixFP4 schemes, not ordinary NVFP4 W4A16."""
+        weights = scheme.weights
+        if module_type != torch.nn.Linear or not cls._is_mixfp4_weight_args(weights):
+            return False
+
+        scheme_format = getattr(scheme.format, "value", scheme.format)
+        observer = getattr(weights, "observer", None)
+        return scheme_format in _MIXFP4_FORMATS or observer in _MIXFP4_OBSERVERS
+
+    @staticmethod
+    def _is_mixfp4_weight_args(weights: QuantizationArgs | None) -> bool:
+        return (
+            weights is not None
+            and weights.num_bits == 4
+            and weights.type == QuantizationType.FLOAT.value
+            and weights.strategy == QuantizationStrategy.TENSOR_GROUP.value
+            and weights.symmetric is True
+            and weights.group_size == 16
+            and weights.scale_dtype in (None, torch.float8_e4m3fn)
+        )
+
+
+def _split_scale(
+    scale: torch.Tensor, global_scale: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (is_int4 flag, effective dequant scale) from flagged FP8 scales."""
+    if global_scale.numel() != 1:
+        raise ValueError("MixFP4 expects a scalar weight_global_scale")
+
+    if scale.dtype != torch.float8_e4m3fn:
+        is_int4 = torch.signbit(scale)
+        mag_fp8 = scale.abs().to(torch.float8_e4m3fn)
+        mag_f32 = mag_fp8.to(torch.float32)
+    else:
+        raw = scale.contiguous().view(torch.uint8)
+        is_int4 = (raw & _FP8_FLAG_BIT).ne(0)
+        mag_fp8 = (raw & 0x7F).view(torch.float8_e4m3fn)
+        mag_f32 = mag_fp8.to(torch.float32)
+
+    gs = global_scale.to(torch.float32).reshape(-1)[0]
+    if not global_scale.is_meta:
+        if not torch.isfinite(gs).item() or gs.item() <= 0:
+            raise ValueError("MixFP4 expects a finite positive weight_global_scale")
+    eff_scale = (mag_f32 / gs).clamp(min=torch.finfo(torch.float32).tiny)
+    return is_int4, eff_scale
+
+
+def pack_mixfp4_to_uint8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    group_size: int = 16,
+) -> torch.Tensor:
+    """Pack a dense weight matrix using per-group MixFP4 scale flags."""
+    if weight.ndim != 2:
+        raise ValueError("MixFP4 weight must be a rank-2 tensor")
+    if group_size <= 0:
+        raise ValueError("MixFP4 group_size must be positive")
+    n, k = weight.shape
+    if k % group_size != 0:
+        raise ValueError(f"weight columns {k} must be divisible by {group_size}")
+    if k % 2 != 0:
+        raise ValueError("MixFP4 packing requires an even number of columns")
+
+    groups = k // group_size
+    if scale.shape != (n, groups):
+        raise ValueError(
+            f"MixFP4 scale shape must be {(n, groups)}, got {tuple(scale.shape)}"
+        )
+    is_int4, eff_scale = _split_scale(
+        scale.to(weight.device), global_scale.to(weight.device)
+    )
+
+    scaled = (
+        weight.to(torch.float32).view(n, groups, group_size) / eff_scale.unsqueeze(-1)
+    )
+    nibble_fp4 = _encode_fp4_nibble(_round_to_e2m1(scaled))
+    q_int4 = scaled.round().clamp(-_INT4_MAX, _INT4_MAX).to(torch.int32)
+    nibble_int4 = _encode_int4_nibble(q_int4)
+
+    nibbles = torch.where(is_int4.unsqueeze(-1), nibble_int4, nibble_fp4).view(n, k)
+    low = nibbles[:, 0::2]
+    high = nibbles[:, 1::2]
+    return ((high << 4) | low).to(torch.uint8)
+
+
+def unpack_mixfp4_from_uint8(
+    weight_packed: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    group_size: int = 16,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Unpack and dequantize MixFP4 weights for validation and decompression."""
+    if weight_packed.dtype != torch.uint8:
+        raise ValueError("MixFP4 packed weights must be uint8")
+    if weight_packed.ndim != 2:
+        raise ValueError("MixFP4 packed weights must be a rank-2 tensor")
+    if group_size <= 0:
+        raise ValueError("MixFP4 group_size must be positive")
+
+    n, k_half = weight_packed.shape
+    k = k_half * 2
+    if k % group_size != 0:
+        raise ValueError(f"packed weight columns {k} must be divisible by {group_size}")
+    groups = k // group_size
+    if scale.shape != (n, groups):
+        raise ValueError(
+            f"MixFP4 scale shape must be {(n, groups)}, got {tuple(scale.shape)}"
+        )
+    is_int4, eff_scale = _split_scale(
+        scale.to(weight_packed.device), global_scale.to(weight_packed.device)
+    )
+
+    low = (weight_packed & 0x0F).to(torch.uint8)
+    high = ((weight_packed >> 4) & 0x0F).to(torch.uint8)
+    nibbles = torch.empty(n, k, dtype=torch.uint8, device=weight_packed.device)
+    nibbles[:, 0::2] = low
+    nibbles[:, 1::2] = high
+
+    val_fp4 = _decode_fp4_nibble(nibbles)
+    val_int4 = _decode_int4_nibble(nibbles)
+    is_int4_elem = is_int4.unsqueeze(-1).expand(n, groups, group_size).reshape(n, k)
+    values = torch.where(is_int4_elem, val_int4, val_fp4)
+    eff_scale_elem = eff_scale.unsqueeze(-1).expand(n, groups, group_size).reshape(n, k)
+    return (values * eff_scale_elem).to(dtype)
+
+
+def _round_to_e2m1(x: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(x.device)
+    sign = torch.sign(x)
+    mag = x.abs().clamp(max=_FP4_MAX)
+    idx = (mag.unsqueeze(-1) - codebook).abs().argmin(dim=-1)
+    return sign * codebook[idx]
+
+
+def _encode_fp4_nibble(q_fp4: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(q_fp4.device)
+    sign_bit = torch.signbit(q_fp4).to(torch.uint8) << 3
+    idx = (q_fp4.abs().unsqueeze(-1) == codebook).to(torch.uint8).argmax(dim=-1)
+    return sign_bit | idx.to(torch.uint8)
+
+
+def _encode_int4_nibble(q_int4: torch.Tensor) -> torch.Tensor:
+    sign_bit = (q_int4 < 0).to(torch.uint8) << 3
+    mag = q_int4.abs().to(torch.uint8).clamp(max=_INT4_MAX)
+    return sign_bit | mag
+
+
+def _decode_fp4_nibble(nibble: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(nibble.device)
+    sign = ((nibble >> 3) & 1).to(torch.bool)
+    mag = codebook[(nibble & 0x07).to(torch.long)]
+    return torch.where(sign, -mag, mag)
+
+
+def _decode_int4_nibble(nibble: torch.Tensor) -> torch.Tensor:
+    sign = ((nibble >> 3) & 1).to(torch.bool)
+    mag = (nibble & 0x07).to(torch.float32)
+    return torch.where(sign, -mag, mag)

--- a/src/compressed_tensors/compressors/mixfp4/base.py
+++ b/src/compressed_tensors/compressors/mixfp4/base.py
@@ -96,13 +96,18 @@ class MixFP4PackedCompressor(BaseCompressor):
         if global_scale is None:
             raise ValueError("MixFP4 compression requires weight_global_scale")
 
+        # During calibration the live qparam tensor may keep the module dtype
+        # (for example bf16). Cast once to the canonical FP8 storage dtype so
+        # the selector bit is interpreted exactly as it will be serialized.
+        scale = cls._compress_scale(scale, weights)
+
         state_dict["weight_packed"] = pack_mixfp4_to_uint8(
             weight=weight,
             scale=scale,
             global_scale=global_scale,
             group_size=weights.group_size,
         )
-        state_dict["weight_scale"] = cls._compress_scale(scale, weights)
+        state_dict["weight_scale"] = scale
         state_dict = cls._remove_symmetric_zp(state_dict, scheme)
         return state_dict
 

--- a/src/compressed_tensors/compressors/mixfp4/base.py
+++ b/src/compressed_tensors/compressors/mixfp4/base.py
@@ -52,15 +52,18 @@ class MixFP4PackedCompressor(BaseCompressor):
     def _compress_scale(
         cls, scale: torch.Tensor, weights: QuantizationArgs
     ) -> torch.Tensor:
+        """Cast flagged per-group scales to the configured storage dtype."""
         scale_dtype = weights.scale_dtype or torch.float8_e4m3fn
         return scale.to(scale_dtype)
 
     @classmethod
     def _decompress_scale(cls, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        """Cast stored scales to the requested dense validation dtype."""
         return scale.to(dtype)
 
     @classmethod
     def _validate_scheme(cls, scheme: QuantizationScheme) -> QuantizationArgs:
+        """Validate that the scheme matches the MixFP4 W4A16 contract."""
         weights = scheme.weights
         if weights is None:
             raise ValueError("MixFP4 compression requires weight quantization args")
@@ -75,6 +78,7 @@ class MixFP4PackedCompressor(BaseCompressor):
     def compress(
         cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
+        """Pack dense weights while preserving flags in ``weight_scale``."""
         state_dict = state_dict.copy()
         weight = state_dict.pop("weight")
         scale = state_dict.pop("weight_scale")
@@ -98,6 +102,7 @@ class MixFP4PackedCompressor(BaseCompressor):
     def decompress(
         cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
+        """Restore dense BF16 weights from packed MixFP4 checkpoint tensors."""
         state_dict = state_dict.copy()
         packed = state_dict.pop("weight_packed")
         scale = state_dict.get("weight_scale")
@@ -135,6 +140,7 @@ class MixFP4PackedCompressor(BaseCompressor):
 
     @staticmethod
     def _is_mixfp4_weight_args(weights: QuantizationArgs | None) -> bool:
+        """Return whether weight args describe symmetric group-16 W4A16 FP4."""
         return (
             weights is not None
             and weights.num_bits == 4

--- a/src/compressed_tensors/compressors/mixfp4/base.py
+++ b/src/compressed_tensors/compressors/mixfp4/base.py
@@ -11,7 +11,10 @@ per-group float8_e4m3fn scales as a block-format flag: 0 selects FP4 E2M1 and
 
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
-from compressed_tensors.compressors.nvfp4.helpers import FLOAT_TO_E2M1
+from compressed_tensors.compressors.mixfp4.helpers import (
+    pack_mixfp4_to_uint8,
+    unpack_mixfp4_from_uint8,
+)
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import (
     QuantizationArgs,
@@ -22,17 +25,9 @@ from compressed_tensors.quantization import (
 from compressed_tensors.utils import TensorStateDict
 
 
-__all__ = [
-    "MixFP4PackedCompressor",
-    "pack_mixfp4_to_uint8",
-    "unpack_mixfp4_from_uint8",
-]
+__all__ = ["MixFP4PackedCompressor"]
 
 
-_E2M1_CODEBOOK = torch.tensor(FLOAT_TO_E2M1, dtype=torch.float32)
-_FP4_MAX = 6.0
-_INT4_MAX = 7
-_FP8_FLAG_BIT = 0x80
 _MIXFP4_FORMATS = {
     CompressionFormat.mixfp4_pack_quantized.value,
     "mixed-fp4-int4-pack-quantized",
@@ -149,143 +144,3 @@ class MixFP4PackedCompressor(BaseCompressor):
             and weights.group_size == 16
             and weights.scale_dtype in (None, torch.float8_e4m3fn)
         )
-
-
-def _split_scale(
-    scale: torch.Tensor, global_scale: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Return (is_int4 flag, effective dequant scale) from flagged FP8 scales."""
-    if global_scale.numel() != 1:
-        raise ValueError("MixFP4 expects a scalar weight_global_scale")
-
-    if scale.dtype != torch.float8_e4m3fn:
-        is_int4 = torch.signbit(scale)
-        mag_fp8 = scale.abs().to(torch.float8_e4m3fn)
-        mag_f32 = mag_fp8.to(torch.float32)
-    else:
-        raw = scale.contiguous().view(torch.uint8)
-        is_int4 = (raw & _FP8_FLAG_BIT).ne(0)
-        mag_fp8 = (raw & 0x7F).view(torch.float8_e4m3fn)
-        mag_f32 = mag_fp8.to(torch.float32)
-
-    gs = global_scale.to(torch.float32).reshape(-1)[0]
-    if not global_scale.is_meta:
-        if not torch.isfinite(gs).item() or gs.item() <= 0:
-            raise ValueError("MixFP4 expects a finite positive weight_global_scale")
-    eff_scale = (mag_f32 / gs).clamp(min=torch.finfo(torch.float32).tiny)
-    return is_int4, eff_scale
-
-
-def pack_mixfp4_to_uint8(
-    weight: torch.Tensor,
-    scale: torch.Tensor,
-    global_scale: torch.Tensor,
-    group_size: int = 16,
-) -> torch.Tensor:
-    """Pack a dense weight matrix using per-group MixFP4 scale flags."""
-    if weight.ndim != 2:
-        raise ValueError("MixFP4 weight must be a rank-2 tensor")
-    if group_size <= 0:
-        raise ValueError("MixFP4 group_size must be positive")
-    n, k = weight.shape
-    if k % group_size != 0:
-        raise ValueError(f"weight columns {k} must be divisible by {group_size}")
-    if k % 2 != 0:
-        raise ValueError("MixFP4 packing requires an even number of columns")
-
-    groups = k // group_size
-    if scale.shape != (n, groups):
-        raise ValueError(
-            f"MixFP4 scale shape must be {(n, groups)}, got {tuple(scale.shape)}"
-        )
-    is_int4, eff_scale = _split_scale(
-        scale.to(weight.device), global_scale.to(weight.device)
-    )
-
-    scaled = (
-        weight.to(torch.float32).view(n, groups, group_size) / eff_scale.unsqueeze(-1)
-    )
-    nibble_fp4 = _encode_fp4_nibble(_round_to_e2m1(scaled))
-    q_int4 = scaled.round().clamp(-_INT4_MAX, _INT4_MAX).to(torch.int32)
-    nibble_int4 = _encode_int4_nibble(q_int4)
-
-    nibbles = torch.where(is_int4.unsqueeze(-1), nibble_int4, nibble_fp4).view(n, k)
-    low = nibbles[:, 0::2]
-    high = nibbles[:, 1::2]
-    return ((high << 4) | low).to(torch.uint8)
-
-
-def unpack_mixfp4_from_uint8(
-    weight_packed: torch.Tensor,
-    scale: torch.Tensor,
-    global_scale: torch.Tensor,
-    group_size: int = 16,
-    dtype: torch.dtype = torch.bfloat16,
-) -> torch.Tensor:
-    """Unpack and dequantize MixFP4 weights for validation and decompression."""
-    if weight_packed.dtype != torch.uint8:
-        raise ValueError("MixFP4 packed weights must be uint8")
-    if weight_packed.ndim != 2:
-        raise ValueError("MixFP4 packed weights must be a rank-2 tensor")
-    if group_size <= 0:
-        raise ValueError("MixFP4 group_size must be positive")
-
-    n, k_half = weight_packed.shape
-    k = k_half * 2
-    if k % group_size != 0:
-        raise ValueError(f"packed weight columns {k} must be divisible by {group_size}")
-    groups = k // group_size
-    if scale.shape != (n, groups):
-        raise ValueError(
-            f"MixFP4 scale shape must be {(n, groups)}, got {tuple(scale.shape)}"
-        )
-    is_int4, eff_scale = _split_scale(
-        scale.to(weight_packed.device), global_scale.to(weight_packed.device)
-    )
-
-    low = (weight_packed & 0x0F).to(torch.uint8)
-    high = ((weight_packed >> 4) & 0x0F).to(torch.uint8)
-    nibbles = torch.empty(n, k, dtype=torch.uint8, device=weight_packed.device)
-    nibbles[:, 0::2] = low
-    nibbles[:, 1::2] = high
-
-    val_fp4 = _decode_fp4_nibble(nibbles)
-    val_int4 = _decode_int4_nibble(nibbles)
-    is_int4_elem = is_int4.unsqueeze(-1).expand(n, groups, group_size).reshape(n, k)
-    values = torch.where(is_int4_elem, val_int4, val_fp4)
-    eff_scale_elem = eff_scale.unsqueeze(-1).expand(n, groups, group_size).reshape(n, k)
-    return (values * eff_scale_elem).to(dtype)
-
-
-def _round_to_e2m1(x: torch.Tensor) -> torch.Tensor:
-    codebook = _E2M1_CODEBOOK.to(x.device)
-    sign = torch.sign(x)
-    mag = x.abs().clamp(max=_FP4_MAX)
-    idx = (mag.unsqueeze(-1) - codebook).abs().argmin(dim=-1)
-    return sign * codebook[idx]
-
-
-def _encode_fp4_nibble(q_fp4: torch.Tensor) -> torch.Tensor:
-    codebook = _E2M1_CODEBOOK.to(q_fp4.device)
-    sign_bit = torch.signbit(q_fp4).to(torch.uint8) << 3
-    idx = (q_fp4.abs().unsqueeze(-1) == codebook).to(torch.uint8).argmax(dim=-1)
-    return sign_bit | idx.to(torch.uint8)
-
-
-def _encode_int4_nibble(q_int4: torch.Tensor) -> torch.Tensor:
-    sign_bit = (q_int4 < 0).to(torch.uint8) << 3
-    mag = q_int4.abs().to(torch.uint8).clamp(max=_INT4_MAX)
-    return sign_bit | mag
-
-
-def _decode_fp4_nibble(nibble: torch.Tensor) -> torch.Tensor:
-    codebook = _E2M1_CODEBOOK.to(nibble.device)
-    sign = ((nibble >> 3) & 1).to(torch.bool)
-    mag = codebook[(nibble & 0x07).to(torch.long)]
-    return torch.where(sign, -mag, mag)
-
-
-def _decode_int4_nibble(nibble: torch.Tensor) -> torch.Tensor:
-    sign = ((nibble >> 3) & 1).to(torch.bool)
-    mag = (nibble & 0x07).to(torch.float32)
-    return torch.where(sign, -mag, mag)

--- a/src/compressed_tensors/compressors/mixfp4/helpers.py
+++ b/src/compressed_tensors/compressors/mixfp4/helpers.py
@@ -18,25 +18,29 @@ def _split_scale(
     scale: torch.Tensor, global_scale: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return (is_int4 flag, effective dequant scale) from flagged FP8 scales."""
-    if global_scale.numel() != 1:
-        raise ValueError("MixFP4 expects a scalar weight_global_scale")
-
     if scale.dtype != torch.float8_e4m3fn:
-        is_int4 = torch.signbit(scale)
-        mag_fp8 = scale.abs().to(torch.float8_e4m3fn)
-        mag_f32 = mag_fp8.to(torch.float32)
-    else:
-        raw = scale.contiguous().view(torch.uint8)
-        is_int4 = (raw & _FP8_FLAG_BIT).ne(0)
-        mag_fp8 = (raw & 0x7F).view(torch.float8_e4m3fn)
-        mag_f32 = mag_fp8.to(torch.float32)
+        raise ValueError("MixFP4 expects float8_e4m3fn weight_scale")
 
-    gs = global_scale.to(torch.float32).reshape(-1)[0]
-    if not global_scale.is_meta:
-        if not torch.isfinite(gs).item() or gs.item() <= 0:
-            raise ValueError("MixFP4 expects a finite positive weight_global_scale")
-    eff_scale = (mag_f32 / gs).clamp(min=torch.finfo(torch.float32).tiny)
+    raw = scale.contiguous().view(torch.uint8)
+    is_int4 = (raw & _FP8_FLAG_BIT).ne(0)
+    mag_fp8 = (raw & 0x7F).view(torch.float8_e4m3fn)
+    mag_f32 = mag_fp8.to(torch.float32)
+
+    eff_scale = _apply_global_scale(mag_f32, global_scale)
     return is_int4, eff_scale
+
+
+def _apply_global_scale(scale: torch.Tensor, global_scale: torch.Tensor) -> torch.Tensor:
+    """Apply NVFP4-style global scale broadcasting."""
+    global_scale = global_scale.to(torch.float32)
+    if not global_scale.is_meta:
+        if not torch.isfinite(global_scale).all().item() or not (
+            global_scale > 0
+        ).all().item():
+            raise ValueError("MixFP4 expects a finite positive weight_global_scale")
+    if global_scale.ndim == 1 and global_scale.numel() == scale.size(0):
+        global_scale = global_scale.reshape(-1, *([1] * (scale.ndim - 1)))
+    return scale / global_scale
 
 
 def pack_mixfp4_to_uint8(
@@ -65,14 +69,19 @@ def pack_mixfp4_to_uint8(
         scale.to(weight.device), global_scale.to(weight.device)
     )
 
+    zero_scale = eff_scale == 0
+    safe_eff_scale = torch.where(zero_scale, torch.ones_like(eff_scale), eff_scale)
     scaled = (
-        weight.to(torch.float32).view(n, groups, group_size) / eff_scale.unsqueeze(-1)
+        weight.to(torch.float32).view(n, groups, group_size)
+        / safe_eff_scale.unsqueeze(-1)
     )
     nibble_fp4 = _encode_fp4_nibble(_round_to_e2m1(scaled))
     q_int4 = scaled.round().clamp(-_INT4_MAX, _INT4_MAX).to(torch.int32)
     nibble_int4 = _encode_int4_nibble(q_int4)
 
-    nibbles = torch.where(is_int4.unsqueeze(-1), nibble_int4, nibble_fp4).view(n, k)
+    nibbles = torch.where(is_int4.unsqueeze(-1), nibble_int4, nibble_fp4)
+    nibbles = torch.where(zero_scale.unsqueeze(-1), torch.zeros_like(nibbles), nibbles)
+    nibbles = nibbles.view(n, k)
     low = nibbles[:, 0::2]
     high = nibbles[:, 1::2]
     return ((high << 4) | low).to(torch.uint8)
@@ -133,7 +142,7 @@ def _encode_fp4_nibble(q_fp4: torch.Tensor) -> torch.Tensor:
     """Encode signed E2M1 FP4 values as one 4-bit code per element."""
     codebook = _E2M1_CODEBOOK.to(q_fp4.device)
     sign_bit = torch.signbit(q_fp4).to(torch.uint8) << 3
-    idx = (q_fp4.abs().unsqueeze(-1) == codebook).to(torch.uint8).argmax(dim=-1)
+    idx = (q_fp4.abs().unsqueeze(-1) - codebook).abs().argmin(dim=-1)
     return sign_bit | idx.to(torch.uint8)
 
 

--- a/src/compressed_tensors/compressors/mixfp4/helpers.py
+++ b/src/compressed_tensors/compressors/mixfp4/helpers.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from compressed_tensors.compressors.nvfp4.helpers import FLOAT_TO_E2M1
+
+
+__all__ = ["pack_mixfp4_to_uint8", "unpack_mixfp4_from_uint8"]
+
+
+_E2M1_CODEBOOK = torch.tensor(FLOAT_TO_E2M1, dtype=torch.float32)
+_FP4_MAX = 6.0
+_INT4_MAX = 7
+_FP8_FLAG_BIT = 0x80
+
+
+def _split_scale(
+    scale: torch.Tensor, global_scale: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (is_int4 flag, effective dequant scale) from flagged FP8 scales."""
+    if global_scale.numel() != 1:
+        raise ValueError("MixFP4 expects a scalar weight_global_scale")
+
+    if scale.dtype != torch.float8_e4m3fn:
+        is_int4 = torch.signbit(scale)
+        mag_fp8 = scale.abs().to(torch.float8_e4m3fn)
+        mag_f32 = mag_fp8.to(torch.float32)
+    else:
+        raw = scale.contiguous().view(torch.uint8)
+        is_int4 = (raw & _FP8_FLAG_BIT).ne(0)
+        mag_fp8 = (raw & 0x7F).view(torch.float8_e4m3fn)
+        mag_f32 = mag_fp8.to(torch.float32)
+
+    gs = global_scale.to(torch.float32).reshape(-1)[0]
+    if not global_scale.is_meta:
+        if not torch.isfinite(gs).item() or gs.item() <= 0:
+            raise ValueError("MixFP4 expects a finite positive weight_global_scale")
+    eff_scale = (mag_f32 / gs).clamp(min=torch.finfo(torch.float32).tiny)
+    return is_int4, eff_scale
+
+
+def pack_mixfp4_to_uint8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    group_size: int = 16,
+) -> torch.Tensor:
+    """Pack a dense weight matrix using per-group MixFP4 scale flags."""
+    if weight.ndim != 2:
+        raise ValueError("MixFP4 weight must be a rank-2 tensor")
+    if group_size <= 0:
+        raise ValueError("MixFP4 group_size must be positive")
+    n, k = weight.shape
+    if k % group_size != 0:
+        raise ValueError(f"weight columns {k} must be divisible by {group_size}")
+    if k % 2 != 0:
+        raise ValueError("MixFP4 packing requires an even number of columns")
+
+    groups = k // group_size
+    if scale.shape != (n, groups):
+        raise ValueError(
+            f"MixFP4 scale shape must be {(n, groups)}, got {tuple(scale.shape)}"
+        )
+    is_int4, eff_scale = _split_scale(
+        scale.to(weight.device), global_scale.to(weight.device)
+    )
+
+    scaled = (
+        weight.to(torch.float32).view(n, groups, group_size) / eff_scale.unsqueeze(-1)
+    )
+    nibble_fp4 = _encode_fp4_nibble(_round_to_e2m1(scaled))
+    q_int4 = scaled.round().clamp(-_INT4_MAX, _INT4_MAX).to(torch.int32)
+    nibble_int4 = _encode_int4_nibble(q_int4)
+
+    nibbles = torch.where(is_int4.unsqueeze(-1), nibble_int4, nibble_fp4).view(n, k)
+    low = nibbles[:, 0::2]
+    high = nibbles[:, 1::2]
+    return ((high << 4) | low).to(torch.uint8)
+
+
+def unpack_mixfp4_from_uint8(
+    weight_packed: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    group_size: int = 16,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Unpack and dequantize MixFP4 weights for validation and decompression."""
+    if weight_packed.dtype != torch.uint8:
+        raise ValueError("MixFP4 packed weights must be uint8")
+    if weight_packed.ndim != 2:
+        raise ValueError("MixFP4 packed weights must be a rank-2 tensor")
+    if group_size <= 0:
+        raise ValueError("MixFP4 group_size must be positive")
+
+    n, k_half = weight_packed.shape
+    k = k_half * 2
+    if k % group_size != 0:
+        raise ValueError(f"packed weight columns {k} must be divisible by {group_size}")
+    groups = k // group_size
+    if scale.shape != (n, groups):
+        raise ValueError(
+            f"MixFP4 scale shape must be {(n, groups)}, got {tuple(scale.shape)}"
+        )
+    is_int4, eff_scale = _split_scale(
+        scale.to(weight_packed.device), global_scale.to(weight_packed.device)
+    )
+
+    low = (weight_packed & 0x0F).to(torch.uint8)
+    high = ((weight_packed >> 4) & 0x0F).to(torch.uint8)
+    nibbles = torch.empty(n, k, dtype=torch.uint8, device=weight_packed.device)
+    nibbles[:, 0::2] = low
+    nibbles[:, 1::2] = high
+
+    val_fp4 = _decode_fp4_nibble(nibbles)
+    val_int4 = _decode_int4_nibble(nibbles)
+    is_int4_elem = is_int4.unsqueeze(-1).expand(n, groups, group_size).reshape(n, k)
+    values = torch.where(is_int4_elem, val_int4, val_fp4)
+    eff_scale_elem = eff_scale.unsqueeze(-1).expand(n, groups, group_size).reshape(n, k)
+    return (values * eff_scale_elem).to(dtype)
+
+
+def _round_to_e2m1(x: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(x.device)
+    sign = torch.sign(x)
+    mag = x.abs().clamp(max=_FP4_MAX)
+    idx = (mag.unsqueeze(-1) - codebook).abs().argmin(dim=-1)
+    return sign * codebook[idx]
+
+
+def _encode_fp4_nibble(q_fp4: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(q_fp4.device)
+    sign_bit = torch.signbit(q_fp4).to(torch.uint8) << 3
+    idx = (q_fp4.abs().unsqueeze(-1) == codebook).to(torch.uint8).argmax(dim=-1)
+    return sign_bit | idx.to(torch.uint8)
+
+
+def _encode_int4_nibble(q_int4: torch.Tensor) -> torch.Tensor:
+    sign_bit = (q_int4 < 0).to(torch.uint8) << 3
+    mag = q_int4.abs().to(torch.uint8).clamp(max=_INT4_MAX)
+    return sign_bit | mag
+
+
+def _decode_fp4_nibble(nibble: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(nibble.device)
+    sign = ((nibble >> 3) & 1).to(torch.bool)
+    mag = codebook[(nibble & 0x07).to(torch.long)]
+    return torch.where(sign, -mag, mag)
+
+
+def _decode_int4_nibble(nibble: torch.Tensor) -> torch.Tensor:
+    sign = ((nibble >> 3) & 1).to(torch.bool)
+    mag = (nibble & 0x07).to(torch.float32)
+    return torch.where(sign, -mag, mag)

--- a/src/compressed_tensors/compressors/mixfp4/helpers.py
+++ b/src/compressed_tensors/compressors/mixfp4/helpers.py
@@ -121,6 +121,7 @@ def unpack_mixfp4_from_uint8(
 
 
 def _round_to_e2m1(x: torch.Tensor) -> torch.Tensor:
+    """Round values to the nearest unsigned E2M1 magnitude with sign."""
     codebook = _E2M1_CODEBOOK.to(x.device)
     sign = torch.sign(x)
     mag = x.abs().clamp(max=_FP4_MAX)
@@ -129,6 +130,7 @@ def _round_to_e2m1(x: torch.Tensor) -> torch.Tensor:
 
 
 def _encode_fp4_nibble(q_fp4: torch.Tensor) -> torch.Tensor:
+    """Encode signed E2M1 FP4 values as one 4-bit code per element."""
     codebook = _E2M1_CODEBOOK.to(q_fp4.device)
     sign_bit = torch.signbit(q_fp4).to(torch.uint8) << 3
     idx = (q_fp4.abs().unsqueeze(-1) == codebook).to(torch.uint8).argmax(dim=-1)
@@ -136,12 +138,14 @@ def _encode_fp4_nibble(q_fp4: torch.Tensor) -> torch.Tensor:
 
 
 def _encode_int4_nibble(q_int4: torch.Tensor) -> torch.Tensor:
+    """Encode signed INT4 values using sign-magnitude nibbles."""
     sign_bit = (q_int4 < 0).to(torch.uint8) << 3
     mag = q_int4.abs().to(torch.uint8).clamp(max=_INT4_MAX)
     return sign_bit | mag
 
 
 def _decode_fp4_nibble(nibble: torch.Tensor) -> torch.Tensor:
+    """Decode one E2M1 FP4 sign-magnitude nibble per element."""
     codebook = _E2M1_CODEBOOK.to(nibble.device)
     sign = ((nibble >> 3) & 1).to(torch.bool)
     mag = codebook[(nibble & 0x07).to(torch.long)]
@@ -149,6 +153,7 @@ def _decode_fp4_nibble(nibble: torch.Tensor) -> torch.Tensor:
 
 
 def _decode_int4_nibble(nibble: torch.Tensor) -> torch.Tensor:
+    """Decode one signed INT4 sign-magnitude nibble per element."""
     sign = ((nibble >> 3) & 1).to(torch.bool)
     mag = (nibble & 0x07).to(torch.float32)
     return torch.where(sign, -mag, mag)

--- a/src/compressed_tensors/config/base.py
+++ b/src/compressed_tensors/config/base.py
@@ -23,8 +23,15 @@ class CompressionFormat(str, Enum):
     marlin_24 = "marlin-24"  # legacy format
     mixed_precision = "mixed-precision"
     nvfp4_pack_quantized = "nvfp4-pack-quantized"
+    mixfp4_pack_quantized = "mixfp4-pack-quantized"
     mxfp4_pack_quantized = "mxfp4-pack-quantized"
     mxfp8_quantized = "mxfp8-quantized"
+
+    @classmethod
+    def _missing_(cls, value):
+        if value == "mixed-fp4-int4-pack-quantized":
+            return cls.mixfp4_pack_quantized
+        return None
 
 
 @unique

--- a/src/compressed_tensors/config/base.py
+++ b/src/compressed_tensors/config/base.py
@@ -29,6 +29,7 @@ class CompressionFormat(str, Enum):
 
     @classmethod
     def _missing_(cls, value):
+        """Canonicalize legacy compression format aliases."""
         if value == "mixed-fp4-int4-pack-quantized":
             return cls.mixfp4_pack_quantized
         return None

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -288,6 +288,7 @@ _INT4_QMAX = 7.0
 
 
 def _is_mixfp4_args(args: QuantizationArgs) -> bool:
+    """Return whether quantization args use a MixFP4 observer marker."""
     return getattr(args, "observer", None) in _MIXFP4_OBSERVERS
 
 
@@ -303,6 +304,7 @@ def _apply_mixfp4_quantize_op(
     do_dequantize: bool,
     global_scale: torch.Tensor | None,
 ) -> torch.Tensor:
+    """Apply MixFP4 fake-quantization using scale sign bits as codebook flags."""
     if zero_point is not None and torch.any(zero_point != 0):
         raise ValueError("MixFP4 only supports symmetric zero points")
 
@@ -332,6 +334,7 @@ def _apply_mixfp4_quantize_op(
 def _split_mixfp4_scale(
     scale: torch.Tensor, global_scale: torch.Tensor | None
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Extract INT4 flags and effective magnitudes from MixFP4 scales."""
     if scale.dtype == torch.float8_e4m3fn:
         raw = scale.contiguous().view(torch.uint8)
         is_int4 = (raw & _MIXFP4_FLAG_BIT).ne(0)

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -305,46 +305,73 @@ def _apply_mixfp4_quantize_op(
     global_scale: torch.Tensor | None,
 ) -> torch.Tensor:
     """Apply MixFP4 fake-quantization using scale sign bits as codebook flags."""
-    if zero_point is not None and torch.any(zero_point != 0):
+    if (
+        zero_point is not None
+        and not zero_point.is_meta
+        and torch.any(zero_point != 0)
+    ):
         raise ValueError("MixFP4 only supports symmetric zero points")
 
     is_int4, effective_scale = _split_mixfp4_scale(scale, global_scale)
+    output_dtype = dtype if dtype is not None else x.dtype
+    zero_scale = effective_scale == 0
+    safe_effective_scale = torch.where(
+        zero_scale, torch.ones_like(effective_scale), effective_scale
+    )
 
     if not do_quantize:
         dequantized = x.to(effective_scale.dtype) * effective_scale
-        if dtype is not None:
-            dequantized = dequantized.to(dtype)
-        return dequantized
+        return dequantized.to(output_dtype)
 
-    scaled = x / effective_scale
+    scaled = x / safe_effective_scale
     fp4_quantized = round_to_quantized_type_args(
         tensor=scaled, args=args, min=q_min, max=q_max
     )
     int4_quantized = scaled.round().clamp(-_INT4_QMAX, _INT4_QMAX)
     quantized = torch.where(is_int4, int4_quantized, fp4_quantized)
+    quantized = torch.where(zero_scale, torch.zeros_like(quantized), quantized)
 
     if not do_dequantize:
-        if dtype is not None:
-            quantized = quantized.to(dtype)
-        return quantized
+        return quantized.to(output_dtype)
 
-    return quantized.to(effective_scale.dtype) * effective_scale
+    return (quantized.to(effective_scale.dtype) * effective_scale).to(output_dtype)
 
 
 def _split_mixfp4_scale(
     scale: torch.Tensor, global_scale: torch.Tensor | None
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Extract INT4 flags and effective magnitudes from MixFP4 scales."""
-    if scale.dtype == torch.float8_e4m3fn:
-        raw = scale.contiguous().view(torch.uint8)
-        is_int4 = (raw & _MIXFP4_FLAG_BIT).ne(0)
-        magnitude = (raw & 0x7F).view(torch.float8_e4m3fn).to(torch.float32)
-    else:
-        is_int4 = torch.signbit(scale)
-        magnitude = scale.abs().to(torch.float8_e4m3fn).to(torch.float32)
+    if scale.dtype != torch.float8_e4m3fn:
+        raise ValueError("MixFP4 expects float8_e4m3fn weight_scale")
+
+    raw = scale.contiguous().view(torch.uint8)
+    is_int4 = (raw & _MIXFP4_FLAG_BIT).ne(0)
+    magnitude = (raw & 0x7F).view(torch.float8_e4m3fn).to(torch.float32)
 
     if global_scale is not None:
-        magnitude = magnitude / global_scale.to(torch.float32)
+        magnitude = _apply_mixfp4_global_scale(magnitude, global_scale)
 
-    effective_scale = magnitude.clamp(min=torch.finfo(torch.float32).tiny)
-    return is_int4, effective_scale
+    return is_int4, magnitude
+
+
+def _apply_mixfp4_global_scale(
+    scale: torch.Tensor, global_scale: torch.Tensor
+) -> torch.Tensor:
+    """Apply NVFP4-style global scale broadcasting."""
+    global_scale = global_scale.to(torch.float32)
+    if not global_scale.is_meta:
+        if not torch.isfinite(global_scale).all().item() or not (
+            global_scale > 0
+        ).all().item():
+            raise ValueError("MixFP4 expects a finite positive weight_global_scale")
+    if global_scale.ndim == 1 and global_scale.numel() == scale.size(0):
+        global_scale = global_scale.reshape(-1, *([1] * (scale.ndim - 1)))
+    elif (
+        global_scale.ndim == 1
+        and scale.ndim > 1
+        and global_scale.numel() == scale.size(-2)
+    ):
+        global_scale = global_scale.reshape(1, -1, *([1] * (scale.ndim - 2)))
+    elif global_scale.ndim == scale.ndim - 1 and scale.shape[-1] == 1:
+        global_scale = global_scale.unsqueeze(-1)
+    return scale / global_scale

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -24,6 +24,20 @@ def _apply_quantize_op(
     global_scale: torch.Tensor | None,
 ) -> torch.Tensor:
     """Dispatch to the appropriate quantization kernel."""
+    if _is_mixfp4_args(args):
+        return _apply_mixfp4_quantize_op(
+            x=x,
+            scale=scale,
+            zero_point=zero_point,
+            q_min=q_min,
+            q_max=q_max,
+            args=args,
+            dtype=dtype,
+            do_quantize=do_quantize,
+            do_dequantize=do_dequantize,
+            global_scale=global_scale,
+        )
+
     if do_quantize and do_dequantize:
         return _quantize_dequantize(
             x=x,
@@ -266,3 +280,68 @@ def _dequantize(
         dequant_value = dequant_value.to(dtype)
 
     return dequant_value
+
+
+_MIXFP4_OBSERVERS = {"mixfp4", "mixed_fp4_int4"}
+_MIXFP4_FLAG_BIT = 0x80
+_INT4_QMAX = 7.0
+
+
+def _is_mixfp4_args(args: QuantizationArgs) -> bool:
+    return getattr(args, "observer", None) in _MIXFP4_OBSERVERS
+
+
+def _apply_mixfp4_quantize_op(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    zero_point: torch.Tensor | None,
+    q_min: torch.Tensor,
+    q_max: torch.Tensor,
+    args: QuantizationArgs,
+    dtype: torch.dtype | None,
+    do_quantize: bool,
+    do_dequantize: bool,
+    global_scale: torch.Tensor | None,
+) -> torch.Tensor:
+    if zero_point is not None and torch.any(zero_point != 0):
+        raise ValueError("MixFP4 only supports symmetric zero points")
+
+    is_int4, effective_scale = _split_mixfp4_scale(scale, global_scale)
+
+    if not do_quantize:
+        dequantized = x.to(effective_scale.dtype) * effective_scale
+        if dtype is not None:
+            dequantized = dequantized.to(dtype)
+        return dequantized
+
+    scaled = x / effective_scale
+    fp4_quantized = round_to_quantized_type_args(
+        tensor=scaled, args=args, min=q_min, max=q_max
+    )
+    int4_quantized = scaled.round().clamp(-_INT4_QMAX, _INT4_QMAX)
+    quantized = torch.where(is_int4, int4_quantized, fp4_quantized)
+
+    if not do_dequantize:
+        if dtype is not None:
+            quantized = quantized.to(dtype)
+        return quantized
+
+    return quantized.to(effective_scale.dtype) * effective_scale
+
+
+def _split_mixfp4_scale(
+    scale: torch.Tensor, global_scale: torch.Tensor | None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scale.dtype == torch.float8_e4m3fn:
+        raw = scale.contiguous().view(torch.uint8)
+        is_int4 = (raw & _MIXFP4_FLAG_BIT).ne(0)
+        magnitude = (raw & 0x7F).view(torch.float8_e4m3fn).to(torch.float32)
+    else:
+        is_int4 = torch.signbit(scale)
+        magnitude = scale.abs().to(torch.float8_e4m3fn).to(torch.float32)
+
+    if global_scale is not None:
+        magnitude = magnitude / global_scale.to(torch.float32)
+
+    effective_scale = magnitude.clamp(min=torch.finfo(torch.float32).tiny)
+    return is_int4, effective_scale

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -137,6 +137,11 @@ class QuantizationConfig(BaseModel):
         updates any quantization schemes defined as presets to be fully loaded
         schemes
         """
+        try:
+            self.format = CompressionFormat(self.format).value
+        except ValueError:
+            pass
+
         for group_name, targets_or_scheme in self.config_groups.items():
             if isinstance(targets_or_scheme, QuantizationScheme):
                 continue  # scheme already defined

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 from enum import Enum
+import logging
 from typing import Annotated, Any
 
 from compressed_tensors.config import CompressionFormat
@@ -14,6 +15,9 @@ from compressed_tensors.quantization.quant_scheme import (
 from compressed_tensors.quantization.utils import is_module_quantized, module_type
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -140,7 +144,9 @@ class QuantizationConfig(BaseModel):
         try:
             self.format = CompressionFormat(self.format).value
         except ValueError:
-            pass
+            _LOGGER.debug(
+                "Unknown compression format %r; leaving it unchanged", self.format
+            )
 
         for group_name, targets_or_scheme in self.config_groups.items():
             if isinstance(targets_or_scheme, QuantizationScheme):

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -180,6 +180,37 @@ NVFP4 = dict(
     ),
 )
 
+MIXFP4A16 = dict(
+    weights=QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.TENSOR_GROUP,
+        symmetric=True,
+        dynamic=False,
+        group_size=16,
+        observer="mixfp4",
+        scale_dtype=FP8_E4M3_DATA.dtype,
+        zp_dtype=FP8_E4M3_DATA.dtype,
+    ),
+    format=CompressionFormat.mixfp4_pack_quantized,
+)
+
+# Backward-compatible preset name used by early MixFP4 experiments.
+NVFP4_INT4_MIXED = dict(
+    weights=QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.TENSOR_GROUP,
+        symmetric=True,
+        dynamic=False,
+        group_size=16,
+        observer="mixed_fp4_int4",
+        scale_dtype=FP8_E4M3_DATA.dtype,
+        zp_dtype=FP8_E4M3_DATA.dtype,
+    ),
+    format=CompressionFormat.mixfp4_pack_quantized,
+)
+
 MXFP4A16 = dict(
     weights=QuantizationArgs(
         num_bits=4,
@@ -421,6 +452,8 @@ PRESET_SCHEMES = {
     "FP8_BLOCK": FP8_BLOCK,
     "NVFP4A16": NVFP4A16,
     "NVFP4": NVFP4,
+    "MIXFP4A16": MIXFP4A16,
+    "NVFP4_INT4_MIXED": NVFP4_INT4_MIXED,
     "MXFP4A16": MXFP4A16,
     "MXFP4": MXFP4,
     "MXFP8A16": MXFP8A16,

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -72,6 +72,8 @@ def _run_compress_decompress(scheme_name, expected_format, actorder, device):
         ("FP8_BLOCK", CompressionFormat.float_quantized, None),
         ("NVFP4A16", CompressionFormat.nvfp4_pack_quantized, None),
         ("NVFP4", CompressionFormat.nvfp4_pack_quantized, None),
+        ("MIXFP4A16", CompressionFormat.mixfp4_pack_quantized, None),
+        ("NVFP4_INT4_MIXED", CompressionFormat.mixfp4_pack_quantized, None),
     ],
 )
 @pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -32,6 +32,11 @@ def _run_compress_decompress(scheme_name, expected_format, actorder, device):
         for name, param in list(module.named_parameters()):
             param.fill_(1)
 
+    if expected_format == CompressionFormat.mixfp4_pack_quantized:
+        module.weight_scale = nn.Parameter(
+            module.weight_scale.to(torch.float8_e4m3fn), requires_grad=False
+        )
+
     # Record pre-compression state dict shapes and dtypes.
     # Filter out None entries (e.g. bias=None when bias=False).
     pre_state = {
@@ -52,6 +57,12 @@ def _run_compress_decompress(scheme_name, expected_format, actorder, device):
         if name in pre_state:
             pre_shape, pre_dtype = pre_state[name]
             assert tensor.shape == pre_shape
+            if (
+                expected_format == CompressionFormat.mixfp4_pack_quantized
+                and name == "weight_scale"
+            ):
+                assert tensor.dtype == torch.bfloat16
+                continue
             assert tensor.dtype == pre_dtype
 
 

--- a/tests/test_compressors/test_mixfp4.py
+++ b/tests/test_compressors/test_mixfp4.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.compressors.format import infer_module_format
@@ -19,9 +20,15 @@ from compressed_tensors.quantization import (
 
 
 def _flagged_scale(is_int4: torch.Tensor) -> torch.Tensor:
-    scale = torch.ones_like(is_int4, dtype=torch.float8_e4m3fn)
+    return _flagged_scale_with_magnitude(torch.ones_like(is_int4), is_int4)
+
+
+def _flagged_scale_with_magnitude(
+    magnitude: torch.Tensor, is_int4: torch.Tensor
+) -> torch.Tensor:
+    scale = magnitude.to(torch.float8_e4m3fn)
     raw = scale.view(torch.uint8).clone()
-    raw |= is_int4.to(torch.uint8) << 7
+    raw = (raw & 0x7F) | (is_int4.to(torch.uint8) << 7)
     return raw.view(torch.float8_e4m3fn)
 
 
@@ -63,6 +70,49 @@ def test_mixfp4_pack_unpack_uses_scale_sign_bit_only():
     assert torch.all(dequant[1] == 1.0)
 
 
+def test_mixfp4_pack_unpack_supports_per_row_global_scale():
+    weight = torch.tensor(
+        [
+            [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+            [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        ],
+        dtype=torch.bfloat16,
+    )
+    scale = _flagged_scale_with_magnitude(
+        torch.tensor([[2.0], [4.0]]), torch.tensor([[True], [False]])
+    )
+    global_scale = torch.tensor([2.0, 4.0], dtype=torch.float32)
+
+    packed = pack_mixfp4_to_uint8(weight, scale, global_scale)
+    dequant = unpack_mixfp4_from_uint8(packed, scale, global_scale, dtype=torch.float32)
+
+    assert torch.equal(dequant, weight.float())
+
+
+def test_mixfp4_pack_unpack_supports_weight_scale_shaped_global_scale():
+    int4_group = torch.tensor(
+        [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+        dtype=torch.bfloat16,
+    )
+    fp4_group = torch.tensor(
+        [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        dtype=torch.bfloat16,
+    )
+    weight = torch.stack(
+        [torch.cat([int4_group, fp4_group]), torch.cat([fp4_group, int4_group])]
+    )
+    scale = _flagged_scale_with_magnitude(
+        torch.tensor([[2.0, 4.0], [8.0, 16.0]]),
+        torch.tensor([[True, False], [False, True]]),
+    )
+    global_scale = torch.tensor([[2.0, 4.0], [8.0, 16.0]], dtype=torch.float32)
+
+    packed = pack_mixfp4_to_uint8(weight, scale, global_scale)
+    dequant = unpack_mixfp4_from_uint8(packed, scale, global_scale, dtype=torch.float32)
+
+    assert torch.equal(dequant, weight.float())
+
+
 def test_mixfp4_legacy_format_alias_is_canonicalized():
     assert (
         CompressionFormat("mixed-fp4-int4-pack-quantized")
@@ -95,6 +145,50 @@ def test_mixfp4_does_not_steal_nvfp4_inference():
         infer_module_format(torch.nn.Linear, mixfp4)
         == CompressionFormat.mixfp4_pack_quantized
     )
+
+
+def test_mixfp4_decompress_scale_strips_selector_bit():
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    state_dict = {
+        "weight": torch.ones((2, 16), dtype=torch.bfloat16),
+        "weight_scale": _flagged_scale(torch.tensor([[False], [True]])),
+        "weight_global_scale": torch.tensor([1.0], dtype=torch.float32),
+    }
+
+    compressed = MixFP4PackedCompressor.compress(state_dict, scheme)
+    compressed_raw = compressed["weight_scale"].view(torch.uint8)
+    assert (compressed_raw[1, 0] & 0x80) != 0
+
+    decompressed = MixFP4PackedCompressor.decompress(compressed, scheme)
+
+    assert torch.equal(
+        decompressed["weight_scale"], torch.ones((2, 1), dtype=torch.bfloat16)
+    )
+    assert torch.all(decompressed["weight_scale"] >= 0)
+
+
+def test_mixfp4_decompress_rejects_non_fp8_scale():
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    state_dict = {
+        "weight_packed": torch.zeros((1, 8), dtype=torch.uint8),
+        "weight_scale": torch.ones((1, 1), dtype=torch.bfloat16),
+        "weight_global_scale": torch.tensor([1.0], dtype=torch.float32),
+    }
+
+    with pytest.raises(ValueError, match="float8_e4m3fn weight_scale"):
+        MixFP4PackedCompressor.decompress(state_dict, scheme)
+
+
+def test_mixfp4_zero_scale_group_packs_to_zero_nibbles():
+    weight = torch.full((1, 16), 7.0, dtype=torch.bfloat16)
+    scale = torch.zeros((1, 1), dtype=torch.float8_e4m3fn)
+    global_scale = torch.tensor([1.0], dtype=torch.float32)
+
+    packed = pack_mixfp4_to_uint8(weight, scale, global_scale)
+    dequant = unpack_mixfp4_from_uint8(packed, scale, global_scale, dtype=torch.float32)
+
+    assert torch.equal(packed, torch.zeros_like(packed))
+    assert torch.equal(dequant, torch.zeros_like(dequant))
 
 
 def test_mixfp4_compress_drops_zero_point_side_metadata():
@@ -137,12 +231,77 @@ def test_mixfp4_rejects_invalid_global_scale():
     scale = _flagged_scale(torch.tensor([[False]]))
 
     for global_scale in (torch.tensor([0.0]), torch.tensor([float("nan")])):
-        try:
+        with pytest.raises(ValueError, match="weight_global_scale"):
             pack_mixfp4_to_uint8(weight, scale, global_scale)
-        except ValueError as err:
-            assert "weight_global_scale" in str(err)
-        else:
-            raise AssertionError("invalid global_scale should be rejected")
+
+
+def test_mixfp4_fake_quantize_preserves_input_dtype():
+    from compressed_tensors.quantization import fake_quantize
+
+    weight = torch.ones((1, 16), dtype=torch.bfloat16)
+    scale = _flagged_scale(torch.tensor([[False]]))
+    zero_point = torch.zeros_like(scale)
+    global_scale = torch.tensor([1.0], dtype=torch.float32)
+    args = preset_name_to_scheme("MIXFP4A16", ["Linear"]).weights
+
+    quantized = fake_quantize(
+        weight, scale, zero_point, args, global_scale=global_scale
+    )
+
+    assert quantized.dtype == torch.bfloat16
+
+
+def test_mixfp4_fake_quantize_supports_per_row_global_scale():
+    from compressed_tensors.quantization import fake_quantize
+
+    weight = torch.tensor(
+        [
+            [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+            [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        ],
+        dtype=torch.bfloat16,
+    )
+    scale = _flagged_scale_with_magnitude(
+        torch.tensor([[2.0], [4.0]]), torch.tensor([[True], [False]])
+    )
+    zero_point = torch.zeros_like(scale)
+    global_scale = torch.tensor([2.0, 4.0], dtype=torch.float32)
+    args = preset_name_to_scheme("MIXFP4A16", ["Linear"]).weights
+
+    quantized = fake_quantize(
+        weight, scale, zero_point, args, global_scale=global_scale
+    )
+
+    assert torch.equal(quantized, weight)
+
+
+def test_mixfp4_fake_quantize_supports_weight_scale_shaped_global_scale():
+    from compressed_tensors.quantization import fake_quantize
+
+    int4_group = torch.tensor(
+        [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+        dtype=torch.bfloat16,
+    )
+    fp4_group = torch.tensor(
+        [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        dtype=torch.bfloat16,
+    )
+    weight = torch.stack(
+        [torch.cat([int4_group, fp4_group]), torch.cat([fp4_group, int4_group])]
+    )
+    scale = _flagged_scale_with_magnitude(
+        torch.tensor([[2.0, 4.0], [8.0, 16.0]]),
+        torch.tensor([[True, False], [False, True]]),
+    )
+    zero_point = torch.zeros_like(scale)
+    global_scale = torch.tensor([[2.0, 4.0], [8.0, 16.0]], dtype=torch.float32)
+    args = preset_name_to_scheme("MIXFP4A16", ["Linear"]).weights
+
+    quantized = fake_quantize(
+        weight, scale, zero_point, args, global_scale=global_scale
+    )
+
+    assert torch.equal(quantized, weight)
 
 
 def test_mixfp4_fake_quantize_interprets_scale_sign_bit():

--- a/tests/test_compressors/test_mixfp4.py
+++ b/tests/test_compressors/test_mixfp4.py
@@ -143,3 +143,27 @@ def test_mixfp4_rejects_invalid_global_scale():
             assert "weight_global_scale" in str(err)
         else:
             raise AssertionError("invalid global_scale should be rejected")
+
+
+def test_mixfp4_fake_quantize_interprets_scale_sign_bit():
+    from compressed_tensors.quantization import fake_quantize
+
+    int4_group = torch.tensor(
+        [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+        dtype=torch.float32,
+    )
+    fp4_group = torch.tensor(
+        [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        dtype=torch.float32,
+    )
+    weight = torch.stack([int4_group, fp4_group])
+    scale = _flagged_scale(torch.tensor([[True], [False]]))
+    zero_point = torch.zeros_like(scale)
+    global_scale = torch.tensor([1.0], dtype=torch.float32)
+    args = preset_name_to_scheme("MIXFP4A16", ["Linear"]).weights
+
+    quantized = fake_quantize(
+        weight, scale, zero_point, args, global_scale=global_scale
+    )
+
+    assert torch.equal(quantized, weight)

--- a/tests/test_compressors/test_mixfp4.py
+++ b/tests/test_compressors/test_mixfp4.py
@@ -179,6 +179,23 @@ def test_mixfp4_decompress_rejects_non_fp8_scale():
         MixFP4PackedCompressor.decompress(state_dict, scheme)
 
 
+def test_mixfp4_compress_casts_live_signed_scale_to_fp8():
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    flagged = _flagged_scale(torch.tensor([[False], [True]]))
+    state_dict = {
+        "weight": torch.ones((2, 16), dtype=torch.bfloat16),
+        "weight_scale": flagged.to(torch.bfloat16),
+        "weight_global_scale": torch.tensor([1.0], dtype=torch.float32),
+    }
+
+    compressed = MixFP4PackedCompressor.compress(state_dict, scheme)
+
+    assert compressed["weight_scale"].dtype == torch.float8_e4m3fn
+    assert torch.equal(
+        compressed["weight_scale"].view(torch.uint8), flagged.view(torch.uint8)
+    )
+
+
 def test_mixfp4_zero_scale_group_packs_to_zero_nibbles():
     weight = torch.full((1, 16), 7.0, dtype=torch.bfloat16)
     scale = torch.zeros((1, 1), dtype=torch.float8_e4m3fn)

--- a/tests/test_compressors/test_mixfp4.py
+++ b/tests/test_compressors/test_mixfp4.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.format import infer_module_format
+from compressed_tensors.compressors.mixfp4 import (
+    MixFP4PackedCompressor,
+    pack_mixfp4_to_uint8,
+    unpack_mixfp4_from_uint8,
+)
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationConfig,
+    QuantizationScheme,
+    preset_name_to_scheme,
+)
+
+
+def _flagged_scale(is_int4: torch.Tensor) -> torch.Tensor:
+    scale = torch.ones_like(is_int4, dtype=torch.float8_e4m3fn)
+    raw = scale.view(torch.uint8).clone()
+    raw |= is_int4.to(torch.uint8) << 7
+    return raw.view(torch.float8_e4m3fn)
+
+
+def test_mixfp4_pack_unpack_uses_scale_sign_bit_only():
+    weight = torch.tensor(
+        [
+            [
+                0.0,
+                0.5,
+                1.0,
+                2.0,
+                3.0,
+                4.0,
+                6.0,
+                -6.0,
+                -7.0,
+                -3.0,
+                -1.0,
+                0.0,
+                1.0,
+                3.0,
+                6.0,
+                7.0,
+            ],
+            [1.0] * 16,
+        ],
+        dtype=torch.bfloat16,
+    )
+    scale = _flagged_scale(torch.tensor([[True], [False]]))
+    global_scale = torch.tensor([1.0], dtype=torch.float32)
+
+    packed = pack_mixfp4_to_uint8(weight, scale, global_scale)
+    dequant = unpack_mixfp4_from_uint8(packed, scale, global_scale, dtype=torch.float32)
+
+    assert packed.shape == (2, 8)
+    assert not hasattr(MixFP4PackedCompressor, "format_flags")
+    assert dequant[0, 8].item() == -7.0
+    assert dequant[0, 15].item() == 7.0
+    assert torch.all(dequant[1] == 1.0)
+
+
+def test_mixfp4_legacy_format_alias_is_canonicalized():
+    assert (
+        CompressionFormat("mixed-fp4-int4-pack-quantized")
+        is CompressionFormat.mixfp4_pack_quantized
+    )
+    assert (
+        BaseCompressor.get_value_from_registry("mixed-fp4-int4-pack-quantized")
+        is MixFP4PackedCompressor
+    )
+    scheme = preset_name_to_scheme("NVFP4_INT4_MIXED", ["Linear"])
+    assert scheme.format == CompressionFormat.mixfp4_pack_quantized
+
+    config = QuantizationConfig(
+        config_groups={"group_1": QuantizationScheme(targets=["Linear"])},
+        format="mixed-fp4-int4-pack-quantized",
+    )
+    assert config.format == CompressionFormat.mixfp4_pack_quantized.value
+    assert config.to_dict()["format"] == CompressionFormat.mixfp4_pack_quantized.value
+
+
+def test_mixfp4_does_not_steal_nvfp4_inference():
+    nvfp4 = preset_name_to_scheme("NVFP4A16", ["Linear"])
+    mixfp4 = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+
+    assert (
+        infer_module_format(torch.nn.Linear, nvfp4)
+        == CompressionFormat.nvfp4_pack_quantized
+    )
+    assert (
+        infer_module_format(torch.nn.Linear, mixfp4)
+        == CompressionFormat.mixfp4_pack_quantized
+    )
+
+
+def test_mixfp4_compress_drops_zero_point_side_metadata():
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    state_dict = {
+        "weight": torch.ones((2, 16), dtype=torch.bfloat16),
+        "weight_scale": _flagged_scale(torch.tensor([[False], [True]])),
+        "weight_global_scale": torch.tensor([1.0], dtype=torch.float32),
+        "weight_zero_point": torch.zeros((2, 1), dtype=torch.float8_e4m3fn),
+    }
+
+    compressed = MixFP4PackedCompressor.compress(state_dict, scheme)
+
+    assert set(compressed) == {
+        "weight_packed",
+        "weight_scale",
+        "weight_global_scale",
+    }
+    assert compressed["weight_scale"].dtype == torch.float8_e4m3fn
+
+
+def test_mixfp4_rejects_non_canonical_storage_contracts():
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    assert MixFP4PackedCompressor.can_compress(torch.nn.Linear, scheme)
+
+    scheme.weights.symmetric = False
+    assert not MixFP4PackedCompressor.can_compress(torch.nn.Linear, scheme)
+
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    scheme.weights.scale_dtype = torch.bfloat16
+    assert not MixFP4PackedCompressor.can_compress(torch.nn.Linear, scheme)
+
+    scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
+    scheme.weights = QuantizationArgs(num_bits=4, type="float", group_size=16)
+    assert not MixFP4PackedCompressor.can_compress(torch.nn.Linear, scheme)
+
+
+def test_mixfp4_rejects_invalid_global_scale():
+    weight = torch.ones((1, 16), dtype=torch.bfloat16)
+    scale = _flagged_scale(torch.tensor([[False]]))
+
+    for global_scale in (torch.tensor([0.0]), torch.tensor([float("nan")])):
+        try:
+            pack_mixfp4_to_uint8(weight, scale, global_scale)
+        except ValueError as err:
+            assert "weight_global_scale" in str(err)
+        else:
+            raise AssertionError("invalid global_scale should be rejected")

--- a/tests/test_quantization/test_configs/test_compression_format.py
+++ b/tests/test_quantization/test_configs/test_compression_format.py
@@ -101,6 +101,7 @@ def test_compression_format_in_config():
         CompressionFormat.naive_quantized,
         CompressionFormat.mixed_precision,
         CompressionFormat.nvfp4_pack_quantized,
+        CompressionFormat.mixfp4_pack_quantized,
         CompressionFormat.mxfp4_pack_quantized,
     ],
 )


### PR DESCRIPTION
# Add MixFP4 compressed tensor format

## Purpose

Add MixFP4 as a compressed-tensors W4A16 weight-only format. MixFP4 is an extension of NVFP4: for each 16-weight group, it compares the reconstruction MSE and chooses whether the elements in that group use the NVFP4 FP4 codebook or the INT4 (E1M2) codebook. MixFP4 keeps the NVFP4-style 4.5 bit/element storage layout and reuses the unused sign bit in each FP8 per-block scale byte as the FP4/INT4 selector.

## Format and usage

Persistent tensors:

- `weight_packed`: 4 bits/element.
- `weight_scale`: one FP8 scale per 16 weights, with bit 7 used as the FP4/INT4 selector.
- `weight_global_scale`: existing per-tensor or per-partition scale.
- No extra selector tensor or side metadata.

Compressed-tensors preset usage:

```python
from compressed_tensors.config import CompressionFormat
from compressed_tensors.quantization import preset_name_to_scheme

scheme = preset_name_to_scheme("MIXFP4A16", ["Linear"])
assert scheme.format == CompressionFormat.mixfp4_pack_quantized
assert scheme.weights.observer == "mixfp4"
```

Low-level pack/unpack helpers are available for tests and tooling:

```python
from compressed_tensors.compressors.mixfp4 import (
    pack_mixfp4_to_uint8,
    unpack_mixfp4_from_uint8,
)

weight_packed = pack_mixfp4_to_uint8(weight, weight_scale, weight_global_scale)
weight = unpack_mixfp4_from_uint8(
    weight_packed, weight_scale, weight_global_scale, dtype=weight_dtype
)
```

## Implementation

- Add canonical compression format `mixfp4-pack-quantized`.
- Add `MIXFP4A16` preset with `observer="mixfp4"`, `type=float`, `strategy=tensor_group`, and `group_size=16`.
- Add `MixFP4PackedCompressor` and MixFP4 pack/unpack helpers.
- In fake-quant/dequant paths, treat the FP8 scale sign bit as the selector instead of a negative scale.
- Cast live signed scales to canonical FP8 storage before packing, while rejecting non-FP8 serialized `weight_scale` on decompression.
- Keep `mixed-fp4-int4-pack-quantized` and `NVFP4_INT4_MIXED` as legacy compatibility aliases.
- Keep ordinary `nvfp4-pack-quantized` routed to the existing NVFP4 path.

## Cross-project workflow

MixFP4 is intended to be used across the compressed-tensors -> llm-compressor -> vLLM stack:

1. `compressed-tensors` defines the canonical `mixfp4-pack-quantized` format, the `MIXFP4A16` preset, and pack/unpack/fake-quant behavior.
2. `llm-compressor` exposes the user-facing quantization recipe: `QuantizationModifier(targets="Linear", scheme="MixFP4A16", ignore=["lm_head"])`.
3. `vLLM` loads the resulting compressed-tensors checkpoint and routes `mixfp4-pack-quantized` W4A16 layers to the MixFP4 Marlin path.

Related PRs:

- compressed-tensors: https://github.com/vllm-project/compressed-tensors/pull/687
- llm-compressor: https://github.com/vllm-project/llm-compressor/pull/2657
- vLLM: https://github.com/vllm-project/vllm/pull/41004

## Shared validation summary

Storage contract:

- Persisted tensors: `weight_packed`, `weight_scale`, `weight_global_scale`.
- `weight_packed` stores 4 bits/element.
- `weight_scale` remains `torch.float8_e4m3fn`, one scale byte per 16 weights; bit 7 stores the FP4/INT4 selector.
- No extra selector tensor or side metadata is emitted.

Accuracy / quality uses lm-eval + vLLM. Math/reasoning uses Qwen math prompts with chat template and math system instruction. MMLU uses lm-eval default `mmlu`, 5-shot, no chat template. WikiText uses lm-eval default `wikitext`; lower PPL is better.

| Model | Quant | GSM8K | MATH500 strict | AIME25 | MMLU | WikiText word PPL |
|---|---|---:|---:|---:|---:|---:|
| Qwen3-8B | BF16 | 93.71% | 76.20% | 70.00% | 74.93% | 13.4838 |
| Qwen3-8B | NVFP4 | 91.58% | 72.00% | 56.67% | 73.55% | 13.7782 |
| Qwen3-8B | MixFP4 | 93.40% | 76.20% | 56.67% | 73.88% | 13.5464 |
| Qwen3-14B | BF16 | 95.07% | 78.80% | 66.67% | 78.82% | 11.6597 |
| Qwen3-14B | NVFP4 | 95.38% | 79.20% | 70.00% | 78.08% | 11.9641 |
| Qwen3-14B | MixFP4 | 94.77% | 76.20% | 66.67% | 78.14% | 11.8100 |

Quality claim: MixFP4 is close to BF16 and improves over NVFP4 on Qwen3-8B for GSM8K, MATH500, MMLU, and WikiText PPL, while tying NVFP4 on AIME25 in the post-fix rerun. On Qwen3-14B, MixFP4 improves WikiText PPL over NVFP4 and is effectively tied on MMLU, while math/reasoning is mixed. AIME25 has only 30 examples, so small-sample deltas should not be overinterpreted.


Latest-vLLM E2E performance on Qwen3-8B with H100 80GB, CUDA 12.8, Torch 2.11, and FA3 enabled:

| Shape | Quant | Wall median ms | Total tok/s median | Decode tok/s median |
|---|---|---:|---:|---:|
| prefill-heavy in=1024 out=32 bs=1 | BF16 | 233.48 | 4522.9 | 148.4 |
| prefill-heavy in=1024 out=32 bs=1 | NVFP4 | 176.25 | 5991.5 | 244.4 |
| prefill-heavy in=1024 out=32 bs=1 | MixFP4 | 187.25 | 5639.6 | 230.1 |
| decode-heavy in=32 out=512 bs=1 | BF16 | 3402.27 | 159.9 | 150.6 |
| decode-heavy in=32 out=512 bs=1 | NVFP4 | 2073.25 | 262.4 | 247.4 |
| decode-heavy in=32 out=512 bs=1 | MixFP4 | 2182.98 | 249.2 | 235.0 |
| batched in=512 out=128 bs=8 | BF16 | 982.90 | 5209.1 | 1141.7 |
| batched in=512 out=128 bs=8 | NVFP4 | 736.97 | 6947.3 | 1837.8 |
| batched in=512 out=128 bs=8 | MixFP4 | 782.96 | 6539.3 | 1751.0 |

MixFP4 is about 5-6% slower than the existing NVFP4 Marlin path in these Qwen3-8B shapes, while remaining substantially faster than BF16 in decode-heavy and batched cases.

## Test Plan

- Run focused MixFP4 compressor/unit coverage.
- Run compressor/decompress module regression coverage.
- Quantize Qwen3-8B and Qwen3-14B with `MixFP4A16` and validate the emitted checkpoint metadata and tensor storage contract.
- Run lm-eval accuracy/PPL and vLLM E2E performance validation through the downstream stack.

## Test Result

- `pytest tests/test_compressors/test_mixfp4.py -q`: `16 passed`.
- Prior compressor regression run: `43 passed, 18 skipped`.
- Qwen3-8B and Qwen3-14B MixFP4A16 checkpoints emit `format: mixfp4-pack-quantized`, `observer: mixfp4`, and only `weight_packed`, `weight_scale`, `weight_global_scale` for quantized weights.

## Dependency / follow-up

This PR should land before the llm-compressor MixFP4A16 recipe PR and the vLLM MixFP4 inference PR.

