### PR TITLE
[KV cache] Delegate structural reads to the wrapped Cache in QuantizedKVCache

### DIFF
--- a/src/compressed_tensors/modeling/kvcache.py
+++ b/src/compressed_tensors/modeling/kvcache.py
@@ -82,6 +82,25 @@ class QuantizedKVCache(InternalModule):
         else:
             self.past_key_values = None
 
+    def __getattr__(self, name: str) -> Any:
+        # During calibration this module replaces the model's `past_key_values`
+        # in the attention kwargs (see `_kv_cache_attention_hook`), so the model
+        # interacts with this wrapper as if it were the real Cache. Most models
+        # only call `update()`, which is handled above. However, transformers>=5
+        # models may also read the cache *structurally* -- e.g. DiffusionGemma's
+        # decoder fetches the encoder cache via `past_key_values.layers[i].keys`
+        # instead of calling `update()`. Such reads would raise AttributeError on
+        # this wrapper. Delegate any attribute this module does not define itself
+        # to the wrapped Cache so structural-API models can be calibrated.
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            past_key_values = self.__dict__.get("past_key_values")
+            cache = past_key_values() if past_key_values is not None else None
+            if cache is not None and name != "past_key_values" and hasattr(cache, name):
+                return getattr(cache, name)
+            raise
+
 
 # ----- initialize ----- #
 

--- a/tests/test_modeling/test_kvcache_structural_read.py
+++ b/tests/test_modeling/test_kvcache_structural_read.py
@@ -39,10 +39,10 @@ def test_genuinely_missing_attribute_still_raises():
     qkv.add_past_key_values(real)
 
     with pytest.raises(AttributeError):
-        qkv.this_attr_does_not_exist_anywhere
+        getattr(qkv, "this_attr_does_not_exist_anywhere")
 
 
 def test_missing_attribute_raises_when_no_cache_attached():
     qkv = _make_qkv_cache()  # past_key_values is None
     with pytest.raises(AttributeError):
-        qkv.layers
+        getattr(qkv, "layers")

--- a/tests/test_modeling/test_kvcache_structural_read.py
+++ b/tests/test_modeling/test_kvcache_structural_read.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from compressed_tensors.modeling.kvcache import QuantizedKVCache
+from transformers import DynamicCache, PretrainedConfig
+
+
+def _make_qkv_cache():
+    # QuantizedKVCache only needs a config and a (weakly referenced) attn module.
+    attn_module = torch.nn.Module()
+    return QuantizedKVCache(PretrainedConfig(), attn_module)
+
+
+def test_structural_read_delegates_to_wrapped_cache():
+    # transformers>=5 models (e.g. DiffusionGemma's decoder) read the cache
+    # structurally via `past_key_values.layers[i].keys` instead of `update()`.
+    # The wrapper must delegate such reads to the real cache instead of raising.
+    real = DynamicCache()
+    key = torch.ones(1, 1, 2, 4)
+    value = torch.zeros(1, 1, 2, 4)
+    real.update(key, value, 0)
+
+    qkv = _make_qkv_cache()
+    qkv.add_past_key_values(real)
+
+    # structural attribute access resolves through to the wrapped cache
+    assert qkv.layers is real.layers
+    assert torch.equal(qkv.layers[0].keys, key)
+    assert torch.equal(qkv.layers[0].values, value)
+
+
+def test_genuinely_missing_attribute_still_raises():
+    real = DynamicCache()
+    real.update(torch.ones(1, 1, 1, 4), torch.ones(1, 1, 1, 4), 0)
+
+    qkv = _make_qkv_cache()
+    qkv.add_past_key_values(real)
+
+    with pytest.raises(AttributeError):
+        qkv.this_attr_does_not_exist_anywhere
+
+
+def test_missing_attribute_raises_when_no_cache_attached():
+    qkv = _make_qkv_cache()  # past_key_values is None
+    with pytest.raises(AttributeError):
+        qkv.layers


### PR DESCRIPTION
## Summary

`QuantizedKVCache` (the module swapped in for `past_key_values` during KV-cache
calibration) only supports the legacy `update()`-interception contract. It
replaces the model's cache in the attention kwargs so it can observe K/V when the
model calls `update()`.

transformers>=5 models may interact with the cache **structurally** instead. For
example, DiffusionGemma's decoder attention fetches the encoder cache via
`past_key_values.layers[i].keys` rather than calling `update()`. Because the
wrapper doesn't proxy attribute access, those reads raise:

```
AttributeError: 'QuantizedKVCache' object has no attribute 'layers'
```

and the model cannot be KV-cache-calibrated at all.

## Fix

Add `__getattr__` to `QuantizedKVCache` that delegates any attribute the wrapper
does not define itself to the wrapped `Cache`. Models that only call `update()`
are unaffected (the delegation path is never taken), and genuinely missing
attributes still raise `AttributeError`.

## Test

`tests/test_modeling/test_kvcache_structural_read.py` (CPU-only) covers:
- structural reads (`qkv.layers[0].keys/.values`) resolve to the wrapped cache,
- a genuinely missing attribute still raises `AttributeError`,
- access raises when no cache is attached.

## Validation

Verified end-to-end downstream: with this change, an `llm-compressor` `oneshot`
NVFP4 (`num_bits=4`) KV-cache calibration of DiffusionGemma-26B-A4B completes
instead of crashing, and the control model (Gemma-4-26B-A4B, which uses
`update()`) is unaffected.

---

AI assistance (Claude) was used to author this change.
