### PR TITLE
[Perf] Add pluggable backend dispatch for quantization lifecycle ops

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/backend.py
+++ b/src/compressed_tensors/quantization/lifecycle/backend.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Pluggable backends for the elementwise quantization lifecycle ops.
+
+The lifecycle leaf ops (``quantize``, ``dequantize``, ``quantize_dequantize``)
+run on every weight/activation group during calibration and are called
+hundreds of thousands of times for even small models (see #766). Routing them
+through a backend registry keeps the reference ``eager`` implementation as the
+default while letting accelerated backends (``torch.compile``, hand written
+triton kernels, ...) register under a name and slot in without touching call
+sites.
+
+The active backend is selected globally via :func:`set_quantization_backend`
+or the ``COMPRESSED_TENSORS_QUANT_BACKEND`` environment variable and defaults
+to ``eager``. A backend that is not usable for a given tensor (per
+:meth:`QuantizationBackend.is_available`) transparently falls back to eager.
+"""
+
+import os
+
+import torch
+from compressed_tensors.quantization.quant_args import (
+    QuantizationArgs,
+    round_to_quantized_type_args,
+)
+from compressed_tensors.registry import RegistryMixin
+
+
+__all__ = [
+    "QuantizationBackend",
+    "EagerQuantizationBackend",
+    "get_quantization_backend",
+    "set_quantization_backend",
+]
+
+_DEFAULT_BACKEND = "eager"
+_ACTIVE_BACKEND = os.environ.get("COMPRESSED_TENSORS_QUANT_BACKEND", _DEFAULT_BACKEND)
+
+
+class QuantizationBackend(RegistryMixin):
+    """Base class for quantization lifecycle backends.
+
+    Subclasses register with :meth:`register` and implement the three leaf ops
+    as static methods. The signatures mirror the historical private helpers so
+    existing call sites are unchanged.
+    """
+
+    registry_requires_subclass = True
+
+    @staticmethod
+    def is_available(x: torch.Tensor, args: QuantizationArgs) -> bool:
+        """Whether this backend can handle the given tensor/args. Backends that
+        return False for a given input are skipped in favor of eager."""
+        return True
+
+    @staticmethod
+    def quantize(
+        x: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor | None,
+        q_min: torch.Tensor,
+        q_max: torch.Tensor,
+        args: QuantizationArgs,
+        dtype: torch.dtype | None = None,
+        global_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    @staticmethod
+    def dequantize(
+        x_q: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor | None = None,
+        global_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    @staticmethod
+    def quantize_dequantize(
+        x: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor | None,
+        q_min: torch.Tensor,
+        q_max: torch.Tensor,
+        args: QuantizationArgs,
+        global_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+
+@QuantizationBackend.register(name="eager")
+class EagerQuantizationBackend(QuantizationBackend):
+    """Reference PyTorch implementation. Bit identical to the pre-dispatch code."""
+
+    @staticmethod
+    def quantize(
+        x, scale, zero_point, q_min, q_max, args, dtype=None, global_scale=None
+    ):
+        # if a global scale is optionally provided, use it
+        # to further scale the local `scale` parameter
+        if global_scale is not None:
+            scale = scale / global_scale
+
+        scaled = x / scale
+
+        if zero_point is not None:
+            scaled += zero_point.to(x.dtype)
+
+        # clamp and round
+        quantized_value = round_to_quantized_type_args(
+            tensor=scaled, args=args, min=q_min, max=q_max
+        )
+
+        if dtype is not None:
+            quantized_value = quantized_value.to(dtype)
+
+        return quantized_value
+
+    @staticmethod
+    def dequantize(x_q, scale, zero_point=None, global_scale=None):
+        # if a global scale is optionally provided, use it
+        # to further scale the local `scale` parameter
+        if global_scale is not None:
+            scale = scale / global_scale
+
+        dequant_value = x_q.to(scale.dtype)
+
+        if zero_point is not None:
+            dequant_value = dequant_value - zero_point.to(scale.dtype)
+
+        return dequant_value * scale
+
+    @staticmethod
+    def quantize_dequantize(
+        x, scale, zero_point, q_min, q_max, args, global_scale=None
+    ):
+        # compute effective scale once
+        if global_scale is not None:
+            scale = scale / global_scale
+
+        scaled = x / scale
+
+        if zero_point is not None:
+            scaled += zero_point.to(x.dtype)
+
+        # clamp and round (stays in float — no int8/fp8 intermediate)
+        quantized = round_to_quantized_type_args(
+            tensor=scaled, args=args, min=q_min, max=q_max
+        )
+
+        # dequantize: subtract zero_point and multiply by scale
+        # cast to scale.dtype to match _dequantize behavior
+        dequant = quantized.to(scale.dtype)
+        if zero_point is not None:
+            dequant = dequant - zero_point.to(scale.dtype)
+
+        return dequant * scale
+
+
+def set_quantization_backend(name: str) -> None:
+    """Set the active quantization backend by registered name.
+
+    :param name: registered backend name (e.g. ``"eager"``). Raises if unknown.
+    """
+    QuantizationBackend.get_value_from_registry(name)  # validate existence
+    global _ACTIVE_BACKEND
+    _ACTIVE_BACKEND = name
+
+
+def get_quantization_backend(
+    x: torch.Tensor | None = None, args: QuantizationArgs | None = None
+) -> type[QuantizationBackend]:
+    """Return the active backend, falling back to eager when the active backend
+    is not available for the given tensor/args."""
+    backend = QuantizationBackend.get_value_from_registry(_ACTIVE_BACKEND)
+    if _ACTIVE_BACKEND != _DEFAULT_BACKEND and x is not None:
+        if not backend.is_available(x, args):
+            return QuantizationBackend.get_value_from_registry(_DEFAULT_BACKEND)
+    return backend

--- a/src/compressed_tensors/quantization/lifecycle/backend.py
+++ b/src/compressed_tensors/quantization/lifecycle/backend.py
@@ -37,6 +37,11 @@ __all__ = [
 _DEFAULT_BACKEND = "eager"
 _ACTIVE_BACKEND = os.environ.get("COMPRESSED_TENSORS_QUANT_BACKEND", _DEFAULT_BACKEND)
 
+# the resolved class for _ACTIVE_BACKEND, cached so the hot path costs one
+# global read instead of a registry lookup per call (resolved lazily on first
+# use so env-configured names are validated after all backends register)
+_ACTIVE_BACKEND_CLS = None
+
 
 class QuantizationBackend(RegistryMixin):
     """Base class for quantization lifecycle backends.
@@ -49,9 +54,10 @@ class QuantizationBackend(RegistryMixin):
     registry_requires_subclass = True
 
     @staticmethod
-    def is_available(x: torch.Tensor, args: QuantizationArgs) -> bool:
-        """Whether this backend can handle the given tensor/args. Backends that
-        return False for a given input are skipped in favor of eager."""
+    def is_available(x: torch.Tensor, args: QuantizationArgs | None = None) -> bool:
+        """Whether this backend can handle the given tensor/args. ``args`` may
+        be None (e.g. dequantize does not carry QuantizationArgs). Backends
+        that return False for a given input are skipped in favor of eager."""
         return True
 
     @staticmethod
@@ -163,8 +169,8 @@ def set_quantization_backend(name: str) -> None:
 
     :param name: registered backend name (e.g. ``"eager"``). Raises if unknown.
     """
-    QuantizationBackend.get_value_from_registry(name)  # validate existence
-    global _ACTIVE_BACKEND
+    global _ACTIVE_BACKEND, _ACTIVE_BACKEND_CLS
+    _ACTIVE_BACKEND_CLS = QuantizationBackend.get_value_from_registry(name)
     _ACTIVE_BACKEND = name
 
 
@@ -172,9 +178,17 @@ def get_quantization_backend(
     x: torch.Tensor | None = None, args: QuantizationArgs | None = None
 ) -> type[QuantizationBackend]:
     """Return the active backend, falling back to eager when the active backend
-    is not available for the given tensor/args."""
-    backend = QuantizationBackend.get_value_from_registry(_ACTIVE_BACKEND)
-    if _ACTIVE_BACKEND != _DEFAULT_BACKEND and x is not None:
+    is not available for the given tensor/args.
+
+    Backend resolution is cached: the common (eager) path costs one global
+    read, and the registry is only consulted when the active backend changes.
+    """
+    global _ACTIVE_BACKEND_CLS
+    backend = _ACTIVE_BACKEND_CLS
+    if backend is None:
+        backend = QuantizationBackend.get_value_from_registry(_ACTIVE_BACKEND)
+        _ACTIVE_BACKEND_CLS = backend
+    if backend is not EagerQuantizationBackend and x is not None:
         if not backend.is_available(x, args):
-            return QuantizationBackend.get_value_from_registry(_DEFAULT_BACKEND)
+            return EagerQuantizationBackend
     return backend

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -4,10 +4,8 @@
 from math import ceil
 
 import torch
-from compressed_tensors.quantization.quant_args import (
-    QuantizationArgs,
-    round_to_quantized_type_args,
-)
+from compressed_tensors.quantization.lifecycle.backend import get_quantization_backend
+from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.utils import maybe_pad_tensor_for_block_quant
 
 
@@ -186,28 +184,19 @@ def _quantize_dequantize(
     Fused quantize-then-dequantize in a single pass, avoiding:
     - Double scale/global_scale division
     - Intermediate quantized dtype allocation
+
+    Routes through the active quantization backend (eager by default); see
+    ``compressed_tensors.quantization.lifecycle.backend``.
     """
-    # compute effective scale once
-    if global_scale is not None:
-        scale = scale / global_scale
-
-    scaled = x / scale
-
-    if zero_point is not None:
-        scaled += zero_point.to(x.dtype)
-
-    # clamp and round (stays in float — no int8/fp8 intermediate)
-    quantized = round_to_quantized_type_args(
-        tensor=scaled, args=args, min=q_min, max=q_max
+    return get_quantization_backend(x, args).quantize_dequantize(
+        x=x,
+        scale=scale,
+        zero_point=zero_point,
+        q_min=q_min,
+        q_max=q_max,
+        args=args,
+        global_scale=global_scale,
     )
-
-    # dequantize: subtract zero_point and multiply by scale
-    # cast to scale.dtype to match _dequantize behavior
-    dequant = quantized.to(scale.dtype)
-    if zero_point is not None:
-        dequant = dequant - zero_point.to(scale.dtype)
-
-    return dequant * scale
 
 
 @torch.no_grad()
@@ -221,25 +210,16 @@ def _quantize(
     dtype: torch.dtype | None = None,
     global_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    # if a global scale is optionally provided, use it
-    # to further scale the local `scale` parameter
-    if global_scale is not None:
-        scale = scale / global_scale
-
-    scaled = x / scale
-
-    if zero_point is not None:
-        scaled += zero_point.to(x.dtype)
-
-    # clamp and round
-    quantized_value = round_to_quantized_type_args(
-        tensor=scaled, args=args, min=q_min, max=q_max
+    return get_quantization_backend(x, args).quantize(
+        x=x,
+        scale=scale,
+        zero_point=zero_point,
+        q_min=q_min,
+        q_max=q_max,
+        args=args,
+        dtype=dtype,
+        global_scale=global_scale,
     )
-
-    if dtype is not None:
-        quantized_value = quantized_value.to(dtype)
-
-    return quantized_value
 
 
 @torch.no_grad()
@@ -250,17 +230,12 @@ def _dequantize(
     dtype: torch.dtype | None = None,
     global_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    # if a global scale is optionally provided, use it
-    # to further scale the local `scale` parameter
-    if global_scale is not None:
-        scale = scale / global_scale
-
-    dequant_value = x_q.to(scale.dtype)
-
-    if zero_point is not None:
-        dequant_value = dequant_value - zero_point.to(scale.dtype)
-
-    dequant_value = dequant_value * scale
+    dequant_value = get_quantization_backend(x_q, None).dequantize(
+        x_q=x_q,
+        scale=scale,
+        zero_point=zero_point,
+        global_scale=global_scale,
+    )
 
     if dtype is not None:
         dequant_value = dequant_value.to(dtype)

--- a/tests/test_quantization/lifecycle/test_backend.py
+++ b/tests/test_quantization/lifecycle/test_backend.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from compressed_tensors.quantization.lifecycle.backend import (
+    EagerQuantizationBackend,
+    QuantizationBackend,
+    get_quantization_backend,
+    set_quantization_backend,
+)
+from compressed_tensors.quantization.lifecycle.forward_helpers import (
+    _dequantize,
+    _quantize,
+    _quantize_dequantize,
+)
+from compressed_tensors.quantization.quant_args import QuantizationArgs
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    # ensure each test starts and ends on the default backend
+    set_quantization_backend("eager")
+    yield
+    set_quantization_backend("eager")
+
+
+def _args():
+    return QuantizationArgs(num_bits=8, symmetric=True)
+
+
+def _reference_qdq(x, scale, zero_point, q_min, q_max, args):
+    from compressed_tensors.quantization.quant_args import round_to_quantized_type_args
+
+    scaled = x / scale
+    if zero_point is not None:
+        scaled = scaled + zero_point.to(x.dtype)
+    quantized = round_to_quantized_type_args(
+        tensor=scaled, args=args, min=q_min, max=q_max
+    )
+    dequant = quantized.to(scale.dtype)
+    if zero_point is not None:
+        dequant = dequant - zero_point.to(scale.dtype)
+    return dequant * scale
+
+
+def test_eager_is_default_backend():
+    assert get_quantization_backend() is EagerQuantizationBackend
+    assert "eager" in QuantizationBackend.registered_names()
+
+
+def test_eager_qdq_matches_reference():
+    torch.manual_seed(0)
+    x = torch.randn(4, 128)
+    scale = torch.tensor(0.05)
+    zp = torch.tensor(0.0)
+    q_min, q_max = torch.tensor(-128.0), torch.tensor(127.0)
+    args = _args()
+
+    got = _quantize_dequantize(x, scale, zp, q_min, q_max, args)
+    ref = _reference_qdq(x, scale, zp, q_min, q_max, args)
+    assert torch.equal(got, ref)
+
+
+def test_quantize_then_dequantize_roundtrip():
+    torch.manual_seed(1)
+    x = torch.randn(8, 64)
+    scale = torch.tensor(0.1)
+    zp = torch.tensor(0.0)
+    q_min, q_max = torch.tensor(-128.0), torch.tensor(127.0)
+    args = _args()
+
+    q = _quantize(x, scale, zp, q_min, q_max, args)
+    dq = _dequantize(q, scale, zp)
+    # dequantized value equals fused qdq
+    assert torch.allclose(dq, _quantize_dequantize(x, scale, zp, q_min, q_max, args))
+
+
+def test_set_unknown_backend_raises():
+    with pytest.raises(Exception):
+        set_quantization_backend("does-not-exist")
+
+
+def test_custom_backend_dispatch_and_fallback():
+    sentinel = torch.tensor([1234.0])
+
+    @QuantizationBackend.register(name="_test_sentinel")
+    class SentinelBackend(QuantizationBackend):
+        available = True
+
+        @staticmethod
+        def is_available(x, args):
+            return SentinelBackend.available
+
+        @staticmethod
+        def quantize_dequantize(
+            x, scale, zero_point, q_min, q_max, args, global_scale=None
+        ):
+            return sentinel
+
+    args = _args()
+    x = torch.randn(2, 8)
+    scale, zp = torch.tensor(0.05), torch.tensor(0.0)
+    q_min, q_max = torch.tensor(-128.0), torch.tensor(127.0)
+
+    set_quantization_backend("_test_sentinel")
+    # dispatched to the custom backend
+    assert torch.equal(_quantize_dequantize(x, scale, zp, q_min, q_max, args), sentinel)
+
+    # when the backend reports unavailable, transparently fall back to eager
+    SentinelBackend.available = False
+    out = _quantize_dequantize(x, scale, zp, q_min, q_max, args)
+    assert not torch.equal(out, sentinel)
+    assert torch.equal(out, _reference_qdq(x, scale, zp, q_min, q_max, args))

--- a/tests/test_quantization/lifecycle/test_backend.py
+++ b/tests/test_quantization/lifecycle/test_backend.py
@@ -77,7 +77,7 @@ def test_quantize_then_dequantize_roundtrip():
 
 
 def test_set_unknown_backend_raises():
-    with pytest.raises(Exception):
+    with pytest.raises(KeyError):
         set_quantization_backend("does-not-exist")
 
 


### PR DESCRIPTION
## Purpose

Towards #766, the "start by replacing the functions with dispatchers" step (design discussed in https://github.com/vllm-project/compressed-tensors/issues/766#issuecomment-4907397585).

The elementwise lifecycle leaf ops (`_quantize`, `_dequantize`, `_quantize_dequantize`) run on every weight/activation group during calibration. Profiling a W4A16 GPTQ run of `Qwen2.5-0.5B-Instruct` (cProfile) shows `_quantize_dequantize` is called 245,760 times for a 0.5B model (billions at Kimi/DeepSeek scale), spending 11.6s of self time in a chain of small elementwise CUDA kernels:

```
ncalls   tottime  cumtime  function
245760    0.26    46.10   forward.py:148 fake_quantize
245760   11.64    25.62   forward_helpers.py:175 _quantize_dequantize
```

This adds a `QuantizationBackend` registry: the reference PyTorch code moves into an `eager` backend (registered by default, bit identical to today), the leaf helpers become thin wrappers that route through the active backend, and accelerated backends (`torch.compile`, hand written triton kernels) can register under a name and are selected per tensor with transparent eager fallback. No behavior change by default; this is the plug in point for the kernels tracked in the rest of #766.

## Changes

- `quantization/lifecycle/backend.py` (new): `QuantizationBackend(RegistryMixin)`, the default `EagerQuantizationBackend` (exact original ops), `get_quantization_backend()` selection with eager fallback, `set_quantization_backend()` / `COMPRESSED_TENSORS_QUANT_BACKEND` env.
- `quantization/lifecycle/forward_helpers.py`: the three leaf helpers route through the active backend; signatures and call sites unchanged.

## Test Plan / Test Result

- `pytest tests/test_quantization/lifecycle/test_backend.py` (new): 5 passed. Eager output is bit identical to the reference formula; quantize/dequantize roundtrip; unknown backend raises; a custom registered backend is dispatched to, and `is_available=False` falls back to eager.
- `pytest tests/test_quantization/lifecycle/` regression: every test that passes on `main` still passes with the dispatcher in place (2 unrelated failures are pre-existing on `main`), confirming the eager path is unchanged.

Built with an AI-assisted engineering workflow (Claude) under my direction: I specified the design, reviewed each iteration, and validated the profiling and test results. Co-authored-by trailer on the commit.
