### PR TITLE
fix: docstring typos and clarify DynamicType.LOCAL constraint to TENSOR_GROUP

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -138,7 +138,8 @@ class DynamicType(str, Enum):
     2. If dynamic is False, all quantization parameters generated are static.
     3. If "local" is provided, only local quantization parameters are dynamic.
 
-    Note: "local" is only currently supported for NVFP4.
+    Note: "local" requires the TENSOR_GROUP strategy, which currently only
+    applies to NVFP4.
 
     """
 
@@ -182,7 +183,7 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
     activations
 
     :param num_bits: quantization bit depth
-    :param type: dtype to quantized to, either int or float
+    :param type: dtype to quantize to, either int or float
     :param symmetric: whether or not quantization scale is symmetric about zero-point
     :param strategy: string id determining the scope of scale/zero-point to apply
     :param group_size: group length to use for the group strategy

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -469,7 +469,7 @@ def round_to_quantized_type_args(
 ) -> torch.Tensor:
     """
     Rounds an input tensor to the nearest quantized representation given
-    qunatization args. The original dtype is kept post-rounding.
+    quantization args. The original dtype is kept post-rounding.
 
     :param tensor: tensor to round
     :param args: quantization args to use for rounding

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -140,13 +140,13 @@ class QuantizationConfig(BaseModel):
         the kv_cache_scheme gets converted into a QuantizationScheme that:
             - targets the `q_proj` and `k_proj` modules of the model. The outputs
               of those modules are the keys and values that might be cached
-            - quantizes the outputs of the aformentioned layers, so that
+            - quantizes the outputs of the aforementioned layers, so that
               keys and values are compressed before storing them in the cache
         There is an explicit assumption that the model contains modules with
         `k_proj` and `v_proj` in their names. If this is not the case
         and kv_cache_scheme != None, the quantization of kv cache will fail
     :global_compression_ratio: optional informational config to report the model
-        compression ratio acheived by the quantization config
+        compression ratio achieved by the quantization config
     :ignore: optional list of layers to ignore from config_groups. Layers in this list
         are not quantized even if they match up with a target in config_groups
     """


### PR DESCRIPTION
This pr targets a few syntactical errors and misrepresentations I found whilst reading through quant args/config:

Note: "local" is only currently supported for NVFP4. -> Note: "local" requires the TENSOR_GROUP strategy, which currently only applies to NVFP4.

reasoning being that the former implies that NVFP4 is the sole scheme for dtype local, when in reality, local requires the tensor_group strategy, and currently NVFP4 is the only scheme under that umbrella.

## Spelling Errors:

### quantization/quant_args.py
- to quantized to -> to quantize to
- qunatization -> quantization

### quantization/quant_config.py
- aformentioned -> aforementioned
- acheived -> achieved
------------------
No tests required as only text changes have been made.