### PR TITLE
Quant buffer pool for triton kernels

### DIFF
--- a/benchmarks/benchmark_buffer_pool.py
+++ b/benchmarks/benchmark_buffer_pool.py
@@ -5,7 +5,6 @@ Tests the Triton kernel with vs without buffer pool across realistic LLM tensor 
 """
 
 import torch
-import time
 import gc
 
 from compressed_tensors.compressors.nvfp4.helpers import (
@@ -31,7 +30,7 @@ device = "cuda:0" if torch.accelerator.is_available() else "cpu"
 
 def create_test_data(size, device):
     """Create test data with exact FP4 values."""
-    x = torch.tensor(FLOAT_TO_E2M1 * (size // 8), dtype=torch.bfloat16, device=device)
+    x = torch.tensor(FLOAT_TO_E2M1 * ((size + 7) // 8), dtype=torch.bfloat16, device=device)
     x = x[:size].reshape(-1, 2)
     x[1::2] = -x[1::2]
     return x
@@ -65,39 +64,45 @@ def benchmark_size(size, name, n_runs=None):
     # Create test data
     test_data = create_test_data(size, device)
     
-    # Warmup both kernels
+    # Warmup both kernels with full-size tensor
+    # Using the actual test size ensures Triton kernel is warmed up for the
+    # correct grid configuration and memory access patterns.
     print("  Warming up kernels...")
-    warmup_data = create_test_data(min(size, 100_000), device)
     for _ in range(5):
-        _ = triton_with_buffer_pool(warmup_data.clone())
-        _ = triton_without_buffer_pool(warmup_data.clone())
-    del warmup_data
-    torch.cuda.empty_cache()
-    gc.collect()
+        _ = triton_with_buffer_pool(test_data)
+        _ = triton_without_buffer_pool(test_data)
     torch.cuda.synchronize()
     
     # Clear buffer pool to start fresh
     QuantBufferPool.clear()
     
-    # Benchmark with buffer pool
+    # Interleaved benchmark using CUDA events for accurate GPU timing.
+    # Alternating between pool and no-pool eliminates ordering bias from
+    # GPU warmup, thermal throttling, and memory state differences.
+    # Note: We don't call torch.cuda.empty_cache() because we want to measure
+    # the realistic comparison: QuantBufferPool vs PyTorch's native caching
+    # allocator. Clearing the cache would force expensive cudaMalloc calls.
     times_pool = []
-    for _ in range(n_runs):
-        torch.cuda.synchronize()
-        start = time.time()
-        result = triton_with_buffer_pool(test_data.clone())
-        torch.cuda.synchronize()
-        times_pool.append(time.time() - start)
-        del result
-    
-    # Benchmark without buffer pool
     times_no_pool = []
     for _ in range(n_runs):
-        torch.cuda.empty_cache()  # Force fresh allocation each time
+        # Run with buffer pool
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        result = triton_with_buffer_pool(test_data)
+        end_event.record()
         torch.cuda.synchronize()
-        start = time.time()
-        result = triton_without_buffer_pool(test_data.clone())
+        times_pool.append(start_event.elapsed_time(end_event) / 1000.0)  # ms to seconds
+        del result
+        
+        # Run without buffer pool
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        result = triton_without_buffer_pool(test_data)
+        end_event.record()
         torch.cuda.synchronize()
-        times_no_pool.append(time.time() - start)
+        times_no_pool.append(start_event.elapsed_time(end_event) / 1000.0)  # ms to seconds
         del result
     
     del test_data

--- a/benchmarks/benchmark_buffer_pool.py
+++ b/benchmarks/benchmark_buffer_pool.py
@@ -1,0 +1,176 @@
+"""
+Benchmark script for pack_fp4_to_uint8 buffer pool comparison.
+
+Tests the Triton kernel with vs without buffer pool across realistic LLM tensor sizes.
+"""
+
+import torch
+import time
+import gc
+
+from compressed_tensors.compressors.nvfp4.helpers import (
+    pack_fp4_to_uint8,
+    QuantBufferPool,
+)
+
+# Realistic tensor sizes based on LLM architectures
+TEST_SIZES = {
+    "Small (1M)":        1_000_000,        # ~1M elements - baseline
+    "7B Attention":     16_777_216,        # 4096 × 4096 = 16.7M
+    "7B MLP":           45_088_768,        # 11008 × 4096 = 45M  
+    "70B Attention":    67_108_864,        # 8192 × 8192 = 67M
+    "70B MLP":         234_881_024,        # 28672 × 8192 = 235M
+    "405B Attention":  268_435_456,        # 16384 × 16384 = 268M
+    "405B MLP":        872_415_232,        # 53248 × 16384 = 872M
+}
+
+FLOAT_TO_E2M1 = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def create_test_data(size, device):
+    """Create test data with exact FP4 values."""
+    x = torch.tensor(FLOAT_TO_E2M1 * (size // 8), dtype=torch.bfloat16, device=device)
+    x = x[:size].reshape(-1, 2)
+    x[1::2] = -x[1::2]
+    return x
+
+
+def triton_with_buffer_pool(x: torch.Tensor) -> torch.Tensor:
+    """Triton kernel using buffer pool (avoids cudaMalloc)."""
+    return pack_fp4_to_uint8(x, use_buffer_pool=True)
+
+
+def triton_without_buffer_pool(x: torch.Tensor) -> torch.Tensor:
+    """Triton kernel without buffer pool (fresh allocation each call)."""
+    return pack_fp4_to_uint8(x, use_buffer_pool=False)
+
+
+def benchmark_size(size, name, n_runs=None):
+    """Benchmark buffer pool vs no buffer pool for a given size."""
+    if n_runs is None:
+        # Adjust runs based on size (fewer for large tensors)
+        if size > 200_000_000:
+            n_runs = 20
+        elif size > 50_000_000:
+            n_runs = 30
+        else:
+            n_runs = 50
+    
+    print(f"\n{'='*80}")
+    print(f"Testing: {name} ({size/1e6:.1f}M elements, ~{size*2/1e6:.1f}MB input, ~{size/2/1e6:.1f}MB output)")
+    print(f"{'='*80}")
+    
+    # Create test data
+    test_data = create_test_data(size, device)
+    
+    # Warmup both kernels
+    print("  Warming up kernels...")
+    warmup_data = create_test_data(min(size, 100_000), device)
+    for _ in range(5):
+        _ = triton_with_buffer_pool(warmup_data.clone())
+        _ = triton_without_buffer_pool(warmup_data.clone())
+    del warmup_data
+    torch.cuda.empty_cache()
+    gc.collect()
+    torch.cuda.synchronize()
+    
+    # Clear buffer pool to start fresh
+    QuantBufferPool.clear()
+    
+    # Benchmark with buffer pool
+    times_pool = []
+    for _ in range(n_runs):
+        torch.cuda.synchronize()
+        start = time.time()
+        result = triton_with_buffer_pool(test_data.clone())
+        torch.cuda.synchronize()
+        times_pool.append(time.time() - start)
+        del result
+    
+    # Benchmark without buffer pool
+    times_no_pool = []
+    for _ in range(n_runs):
+        torch.cuda.empty_cache()  # Force fresh allocation each time
+        torch.cuda.synchronize()
+        start = time.time()
+        result = triton_without_buffer_pool(test_data.clone())
+        torch.cuda.synchronize()
+        times_no_pool.append(time.time() - start)
+        del result
+    
+    del test_data
+    torch.cuda.empty_cache()
+    gc.collect()
+    
+    avg_pool = sum(times_pool) / len(times_pool)
+    avg_no_pool = sum(times_no_pool) / len(times_no_pool)
+    
+    return {
+        "name": name,
+        "size": size,
+        "time_pool": avg_pool,
+        "time_no_pool": avg_no_pool,
+    }
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("CUDA not available, Triton requires GPU")
+        return
+
+    print("="*80)
+    print("BUFFER POOL BENCHMARK - Realistic LLM Tensor Sizes")
+    print("="*80)
+    print(f"Device: {torch.cuda.get_device_name(0)}")
+    print(f"Testing pack_fp4_to_uint8 with vs without buffer pool")
+    
+    results = []
+    
+    for name, size in TEST_SIZES.items():
+        try:
+            result = benchmark_size(size, name)
+            results.append(result)
+            
+            speedup = result["time_no_pool"] / result["time_pool"] if result["time_pool"] > 0 else 0
+            diff_ms = (result["time_no_pool"] - result["time_pool"]) * 1000
+            
+            print(f"\n  With buffer pool:    {result['time_pool']*1000:>8.3f} ms")
+            print(f"  Without buffer pool: {result['time_no_pool']*1000:>8.3f} ms")
+            print(f"  Buffer pool effect:  {speedup:.3f}x ({diff_ms:+.3f} ms)")
+            
+        except torch.cuda.OutOfMemoryError:
+            print(f"  SKIPPED - Out of memory")
+            continue
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            continue
+    
+    # Final summary table
+    print("\n")
+    print("="*100)
+    print("SUMMARY: Buffer Pool Effect Across Tensor Sizes")
+    print("="*100)
+    print(f"{'Tensor Size':<20} {'Elements':<12} {'Output':<10} {'With Pool':<12} {'No Pool':<12} {'Effect':<10} {'Diff':<10}")
+    print("-"*100)
+    
+    for r in results:
+        speedup = r["time_no_pool"] / r["time_pool"] if r["time_pool"] > 0 else 0
+        diff_ms = (r["time_no_pool"] - r["time_pool"]) * 1000
+        output_mb = r["size"] / 2 / 1e6
+        
+        effect_str = f"{speedup:.2f}x" if speedup >= 1 else f"{speedup:.2f}x"
+        diff_str = f"{diff_ms:+.2f}ms"
+        
+        print(f"{r['name']:<20} {r['size']/1e6:>8.1f}M   {output_mb:>6.1f}MB  "
+              f"{r['time_pool']*1000:>8.2f}ms   {r['time_no_pool']*1000:>8.2f}ms   "
+              f"{effect_str:>8}   {diff_str:>8}")
+    
+    print("-"*100)
+    print("\nNote: Effect > 1.0x means buffer pool is FASTER, < 1.0x means SLOWER")
+    print("      Positive diff means buffer pool saves time, negative means overhead")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_buffer_pool.py
+++ b/benchmarks/benchmark_buffer_pool.py
@@ -26,7 +26,7 @@ TEST_SIZES = {
 
 FLOAT_TO_E2M1 = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
 
-device = "cuda:0" if torch.cuda.is_available() else "cpu"
+device = "cuda:0" if torch.accelerator.is_available() else "cpu"
 
 
 def create_test_data(size, device):
@@ -116,7 +116,7 @@ def benchmark_size(size, name, n_runs=None):
 
 
 def main():
-    if not torch.cuda.is_available():
+    if not torch.accelerator.is_available():
         print("CUDA not available, Triton requires GPU")
         return
 

--- a/src/compressed_tensors/compressors/nvfp4/base.py
+++ b/src/compressed_tensors/compressors/nvfp4/base.py
@@ -23,6 +23,10 @@ from compressed_tensors.utils import TensorStateDict, getattr_chain
 
 __all__ = ["NVFP4PackedCompressor"]
 
+# Minimum output size (in bytes) to use buffer pool for pack_fp4_to_uint8.
+# Below this threshold, PyTorch's caching allocator is faster.
+_BUFFER_POOL_MIN_BYTES = 8_000_000  # ~8MB
+
 
 @BaseCompressor.register(name=CompressionFormat.nvfp4_pack_quantized.value)
 class NVFP4PackedCompressor(BaseCompressor):
@@ -89,7 +93,16 @@ class NVFP4PackedCompressor(BaseCompressor):
             zero_point=zero_point,
             args=weights,
         )
-        state_dict["weight_packed"] = pack_fp4_to_uint8(quantized_weight)
+
+        # Use buffer pool only for large tensors where it provides benefit
+        output_bytes = (
+            quantized_weight.numel() // 2
+        )  # packed output is half the elements
+        use_buffer_pool = output_bytes >= _BUFFER_POOL_MIN_BYTES
+
+        state_dict["weight_packed"] = pack_fp4_to_uint8(
+            quantized_weight, use_buffer_pool=use_buffer_pool
+        )
         state_dict["weight_scale"] = cls._compress_scale(scale, weights)
         state_dict = cls._remove_symmetric_zp(state_dict, scheme)
 

--- a/src/compressed_tensors/compressors/nvfp4/helpers.py
+++ b/src/compressed_tensors/compressors/nvfp4/helpers.py
@@ -12,9 +12,14 @@ packing of two FP4 values into a single uint8 for storage.
 import torch
 import triton
 import triton.language as tl
+from compressed_tensors.quantization.lifecycle.forward_helpers import QuantBufferPool
 
 
-__all__ = ["pack_fp4_to_uint8", "unpack_fp4_from_uint8"]
+__all__ = [
+    "pack_fp4_to_uint8",
+    "unpack_fp4_from_uint8",
+    "QuantBufferPool",
+]
 
 
 FLOAT_TO_E2M1 = [
@@ -98,7 +103,10 @@ def _pack_fp4_kernel(
     tl.store(packed_ptr + offsets, packed, mask=mask)
 
 
-def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
+def pack_fp4_to_uint8(
+    x: torch.Tensor,
+    use_buffer_pool: bool = True,
+) -> torch.Tensor:
     """
     Packs a tensor with values in the fp4 range into uint8.
     As there are 16 valid fp4 values, two fp4 values can be
@@ -112,6 +120,7 @@ def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
     called after _cast_to_fp4() or equivalent quantization.
 
     :param x: tensor to pack
+    :param use_buffer_pool: if True, reuse buffers to avoid cudaMalloc overhead
     :returns: a packed tensor in uint8
     """
     m, n = x.shape
@@ -126,7 +135,11 @@ def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
         x_flat = x.contiguous().flatten()
         n_pairs = x_flat.numel() // 2
 
-        packed = torch.empty(n_pairs, dtype=torch.uint8, device=x.device)
+        # Use buffer pool to avoid repeated cudaMalloc calls
+        if use_buffer_pool:
+            packed = QuantBufferPool.get_buffer((n_pairs,), torch.uint8, x.device)
+        else:
+            packed = torch.empty(n_pairs, dtype=torch.uint8, device=x.device)
 
         BLOCK_SIZE = 1024
         grid = (triton.cdiv(n_pairs, BLOCK_SIZE),)

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from math import ceil
+import threading
+from math import ceil, prod
 
 import torch
 from compressed_tensors.quantization.quant_args import (
@@ -9,6 +10,90 @@ from compressed_tensors.quantization.quant_args import (
     round_to_quantized_type_args,
 )
 from compressed_tensors.quantization.utils import maybe_pad_tensor_for_block_quant
+
+
+class QuantBufferPool:
+    """
+    Thread-local buffer pool for quantization output tensors.
+
+    Allocates a single large buffer per device and returns views into it,
+    avoiding repeated cudaMalloc calls. The buffer grows dynamically to
+    accommodate the largest tensor seen, then stays at that size.
+
+    Based on vLLM's WorkspaceManager pattern (vllm/v1/worker/workspace.py).
+    """
+
+    _local = threading.local()
+
+    @classmethod
+    def _get_pool(cls, device: torch.device) -> dict:
+        """Get or create the buffer pool for this thread."""
+        if not hasattr(cls._local, "pools"):
+            cls._local.pools = {}
+
+        device_key = str(device)
+        if device_key not in cls._local.pools:
+            cls._local.pools[device_key] = {
+                "buffer": None,
+                "size": 0,
+            }
+        return cls._local.pools[device_key]
+
+    @classmethod
+    def get_buffer(
+        cls,
+        shape: tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """
+        Get a buffer of the requested shape and dtype.
+
+        Returns a view into a pre-allocated buffer. If the buffer is too small,
+        it grows to accommodate the request. The buffer is stored as uint8 and
+        views are created with the requested dtype.
+
+        Args:
+            shape: The shape of the tensor to return
+            dtype: The dtype of the tensor to return
+            device: The device to allocate on
+
+        Returns:
+            A tensor view of the requested shape and dtype
+        """
+        pool = cls._get_pool(device)
+
+        num_bytes = prod(shape) * dtype.itemsize
+
+        # Grow buffer if needed
+        if pool["size"] < num_bytes:
+            # Free old buffer
+            pool["buffer"] = None
+            # Allocate new larger buffer
+            pool["buffer"] = torch.empty(num_bytes, dtype=torch.uint8, device=device)
+            pool["size"] = num_bytes
+
+        # Return a view of the appropriate size and dtype
+        return pool["buffer"][:num_bytes].view(dtype).reshape(shape)
+
+    @classmethod
+    def clear(cls, device: torch.device | None = None):
+        """
+        Clear cached buffers to free memory.
+
+        Args:
+            device: If specified, only clear the buffer for this device.
+                   If None, clear all buffers.
+        """
+        if not hasattr(cls._local, "pools"):
+            return
+
+        if device is not None:
+            device_key = str(device)
+            if device_key in cls._local.pools:
+                cls._local.pools[device_key] = {"buffer": None, "size": 0}
+        else:
+            cls._local.pools.clear()
 
 
 def _apply_quantize_op(

--- a/tests/test_compressors/test_fp4_optimizations.py
+++ b/tests/test_compressors/test_fp4_optimizations.py
@@ -62,7 +62,7 @@ def test_pack_fp4_to_uint8(device, test_input):
 @pytest.mark.parametrize("device", ["cuda"])
 def test_pack_fp4_to_uint8_float32_input(device):
     """Test pack_fp4_to_uint8 accepts float32 inputs in the valid FP4 set."""
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
     from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8

--- a/tests/test_quantization/lifecycle/test_buffer_pool.py
+++ b/tests/test_quantization/lifecycle/test_buffer_pool.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8
+from compressed_tensors.quantization.lifecycle.forward_helpers import QuantBufferPool
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestQuantBufferPoolCUDA:
+    """CUDA-specific tests for QuantBufferPool."""
+
+    def setup_method(self):
+        QuantBufferPool.clear()
+
+    def teardown_method(self):
+        QuantBufferPool.clear()
+
+    def test_cuda_basic(self):
+        """Buffer works on CUDA device."""
+        shape = (100, 100)
+        dtype = torch.float32
+        device = torch.device("cuda:0")
+
+        buf = QuantBufferPool.get_buffer(shape, dtype, device)
+
+        assert buf.shape == shape
+        assert buf.dtype == dtype
+        assert buf.is_cuda
+
+    def test_cuda_buffer_reuse(self):
+        """CUDA buffer is reused for same size requests."""
+        shape = (100, 100)
+        dtype = torch.float32
+        device = torch.device("cuda:0")
+
+        buf1 = QuantBufferPool.get_buffer(shape, dtype, device)
+        ptr1 = buf1.data_ptr()
+
+        buf2 = QuantBufferPool.get_buffer(shape, dtype, device)
+        ptr2 = buf2.data_ptr()
+
+        assert ptr1 == ptr2, "CUDA buffer should be reused"
+
+    def test_separate_pools_per_device(self):
+        """CPU and CUDA have separate pools."""
+        shape = (100, 100)
+        dtype = torch.float32
+
+        cpu_buf = QuantBufferPool.get_buffer(shape, dtype, torch.device("cpu"))
+        cuda_buf = QuantBufferPool.get_buffer(shape, dtype, torch.device("cuda:0"))
+
+        assert not cpu_buf.is_cuda
+        assert cuda_buf.is_cuda
+        # Different devices should have different pools
+        assert cpu_buf.data_ptr() != cuda_buf.data_ptr()
+
+    def test_pack_fp4_with_vs_without_buffer_pool(self):
+        """pack_fp4_to_uint8 produces identical results with and without buffer pool."""
+        # Create random FP4 indices (0-15 representing the 16 FP4 values)
+        shape = (4096, 4096)
+        x = torch.randint(0, 16, shape, dtype=torch.uint8, device="cuda")
+
+        # Pack without buffer pool
+        packed_without = pack_fp4_to_uint8(x, use_buffer_pool=False)
+
+        # Pack with buffer pool
+        QuantBufferPool.clear()
+        packed_with = pack_fp4_to_uint8(x, use_buffer_pool=True)
+
+        assert torch.equal(packed_without, packed_with), (
+            "pack_fp4_to_uint8 should produce identical results "
+            "with and without buffer pool"
+        )

--- a/tests/test_quantization/lifecycle/test_buffer_pool.py
+++ b/tests/test_quantization/lifecycle/test_buffer_pool.py
@@ -7,7 +7,7 @@ from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8
 from compressed_tensors.quantization.lifecycle.forward_helpers import QuantBufferPool
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not torch.accelerator.is_available(), reason="CUDA not available")
 class TestQuantBufferPoolCUDA:
     """CUDA-specific tests for QuantBufferPool."""
 


### PR DESCRIPTION
For larger output tensors, store the output tensor in a buffer that persists across `pack_fp4_to_uint8` calls to avoid expesive memory re-allocation.

### Evaluation
Done with `benchmarks/benchmark_buffer_pool.py`.
```
====================================================================================================
SUMMARY: Buffer Pool Effect Across Tensor Sizes
====================================================================================================
Tensor Size          Elements     Output     With Pool    No Pool      Effect     Diff      
----------------------------------------------------------------------------------------------------
Small (1M)                1.0M      0.5MB      0.05ms       0.04ms      0.73x    -0.01ms
7B Attention             16.8M      8.4MB      0.07ms       0.14ms      1.94x    +0.07ms
7B MLP                   45.1M     22.5MB      0.14ms       0.39ms      2.77x    +0.25ms
70B Attention            67.1M     33.6MB      0.20ms       0.58ms      2.87x    +0.38ms
70B MLP                 234.9M    117.4MB      0.63ms       1.53ms      2.45x    +0.91ms
405B Attention          268.4M    134.2MB      0.71ms       1.69ms      2.38x    +0.98ms
405B MLP                872.4M    436.2MB      2.22ms       3.40ms      1.53x    +1.18ms
----------------------------------------------------------------------------------------------------
Note: Effect > 1.0x means buffer pool is FASTER, < 1.0x means SLOWER
      Positive diff means buffer pool saves time, negative means overhead
```