### PR TITLE
Skip default-valued fields during QuantizationArgs serialization

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -14,6 +14,7 @@ from pydantic import (
     Field,
     field_serializer,
     field_validator,
+    model_serializer,
     model_validator,
 )
 
@@ -231,6 +232,26 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
             return None
         return str(dtype)
 
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+
+        # Omit fields that are None when not explicitly user-specified
+        for field in ("actorder", "block_structure", "scale_dtype"):
+            if data.get(field) is None:
+                data.pop(field, None)
+
+        # Omit empty observer_kwargs
+        if not data.get("observer_kwargs"):
+            data.pop("observer_kwargs", None)
+
+        # Omit observer and zp_dtype when not explicitly user-specified or when None
+        for field in ("observer", "zp_dtype"):
+            if field not in self.model_fields_set or data.get(field) is None:
+                data.pop(field, None)
+
+        return data
+
     @field_validator("type", mode="before")
     def validate_type(cls, value) -> QuantizationType:
         if isinstance(value, str):
@@ -301,6 +322,10 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
 
     @model_validator(mode="after")
     def validate_model_after(model: "QuantizationArgs") -> "QuantizationArgs":
+        # Capture which fields the user explicitly provided before this validator
+        # modifies any fields via __setattr__ (which would otherwise expand model_fields_set)
+        _user_provided = set(model.model_fields_set)
+
         # extract user-passed values from dictionary
         strategy = model.strategy
         group_size = model.group_size
@@ -410,6 +435,13 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         model.strategy = strategy
         model.observer = observer
         model.zp_dtype = zp_dtype
+
+        # Restore model_fields_set to only the fields explicitly provided by the user,
+        # undoing any additions made by the __setattr__ calls above. This ensures
+        # that inferred fields (observer, zp_dtype, strategy) are not mistakenly
+        # treated as user-specified during serialization.
+        object.__setattr__(model, "__pydantic_fields_set__", _user_provided)
+
         return model
 
     def pytorch_dtype(self) -> torch.dtype:

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -184,6 +184,88 @@ def test_serialize_args():
     assert reloaded == args
 
 
+def test_default_fields_not_serialized():
+    """
+    Fields actorder, block_structure, observer, observer_kwargs, scale_dtype,
+    and zp_dtype are omitted from model_dump() when not explicitly set.
+
+    Before this change, model_dump() on QuantizationArgs() would produce:
+        {
+            "num_bits": 8, "type": "int", "symmetric": True,
+            "group_size": None, "strategy": "tensor", "dynamic": False,
+            "actorder": None,
+            "block_structure": None,
+            "observer": "memoryless_minmax",
+            "observer_kwargs": {},
+            "scale_dtype": None,
+            "zp_dtype": None,  # None because symmetric=True
+        }
+
+    After this change, model_dump() on QuantizationArgs() produces:
+        {
+            "num_bits": 8, "type": "int", "symmetric": True,
+            "group_size": None, "strategy": "tensor", "dynamic": False,
+        }
+    """
+    args = QuantizationArgs()
+    serialized = args.model_dump()
+
+    assert "actorder" not in serialized
+    assert "block_structure" not in serialized
+    assert "observer" not in serialized
+    assert "observer_kwargs" not in serialized
+    assert "scale_dtype" not in serialized
+    assert "zp_dtype" not in serialized
+
+    # Core fields are still present
+    assert serialized["num_bits"] == 8
+    assert serialized["type"] == "int"
+    assert serialized["strategy"] == "tensor"
+
+
+def test_explicit_fields_are_serialized():
+    """Explicitly set optional fields appear in model_dump()."""
+    args = QuantizationArgs(
+        group_size=128,
+        actorder=ActivationOrdering.GROUP,
+        observer="minmax",
+        observer_kwargs={"percentile": 99.9},
+        scale_dtype=torch.float16,
+    )
+    serialized = args.model_dump()
+
+    assert serialized["actorder"] == "group"
+    assert serialized["observer"] == "minmax"
+    assert serialized["observer_kwargs"] == {"percentile": 99.9}
+    assert "scale_dtype" in serialized
+
+
+def test_explicit_zp_dtype_serialized_when_asymmetric():
+    """Explicitly set zp_dtype is serialized for asymmetric quantization."""
+    args = QuantizationArgs(symmetric=False, zp_dtype=torch.int16)
+    serialized = args.model_dump()
+    assert "zp_dtype" in serialized
+    assert serialized["zp_dtype"] == "torch.int16"
+
+
+def test_zp_dtype_not_serialized_when_symmetric():
+    """zp_dtype is omitted when symmetric=True even if explicitly set, since it is unused."""
+    args = QuantizationArgs(symmetric=True, zp_dtype=torch.int8)
+    serialized = args.model_dump()
+    assert "zp_dtype" not in serialized
+
+
+def test_round_trip_with_optional_fields_omitted():
+    """Serializing and deserializing default args produces equivalent args."""
+    for args in (
+        QuantizationArgs(),
+        QuantizationArgs(group_size=128, actorder=ActivationOrdering.GROUP),
+        QuantizationArgs(num_bits=4, type=QuantizationType.INT, group_size=128),
+    ):
+        reloaded = QuantizationArgs.model_validate(args.model_dump())
+        assert args == reloaded
+
+
 def test_cast_to_fp4_no_recompile_across_ranks():
     # https://github.com/vllm-project/compressed-tensors/issues/734
     # rank-varying inputs must not recompile the compiled fp4 rounding core


### PR DESCRIPTION
## Summary

- `actorder`, `block_structure`, `observer`, `observer_kwargs`, `scale_dtype`, and `zp_dtype` are no longer serialized when not explicitly set or when at their default values
- Adds a `@model_serializer(mode="wrap")` to `QuantizationArgs` that conditionally omits these fields
- Captures the user-provided `model_fields_set` at the start of `validate_model_after` (before the validator expands it via `__setattr__`) and restores it afterward, so inferred fields (`observer`, `zp_dtype`, `strategy`) are not misclassified as user-specified

## Before / After

**Before** — `QuantizationArgs().model_dump()`:
```python
{
    "num_bits": 8, "type": "int", "symmetric": True,
    "group_size": None, "strategy": "tensor", "dynamic": False,
    "actorder": None,               # noise
    "block_structure": None,        # noise
    "observer": "memoryless_minmax",# noise
    "observer_kwargs": {},          # noise
    "scale_dtype": None,            # noise
    "zp_dtype": None,               # noise (None because symmetric=True)
}
```

**After** — `QuantizationArgs().model_dump()`:
```python
{
    "num_bits": 8, "type": "int", "symmetric": True,
    "group_size": None, "strategy": "tensor", "dynamic": False,
}
```

Explicitly set fields are still serialized normally:
```python
QuantizationArgs(group_size=128, observer="minmax", observer_kwargs={"percentile": 99.9}).model_dump()
# → includes observer, observer_kwargs in output
```

Round-trip deserialization is preserved — the omitted fields are re-inferred by `validate_model_after` on load.