### PR TITLE
[Offload] Support views

### DIFF
--- a/src/compressed_tensors/offload/README.md
+++ b/src/compressed_tensors/offload/README.md
@@ -82,7 +82,7 @@ class OffloadCache(MutableMapping, ABC):
 |---|---|
 | `cls_from_device(device)` | Returns the correct `OffloadCache` subclass for the given offload device and distributed state. Automatically selects distributed variants when `dist` is initialized. |
 | `from_mapping(mapping, onload_device, **kwargs)` | Class method. Constructs an `OffloadCache` from an existing dict (e.g., `module._parameters`), offloading all values immediately. This is the canonical way to attach a cache to a module. |
-| `onload(offloaded)` | *(abstract)* Given an offloaded tensor, returns the onloaded version. |
+| `onload(key, offloaded)` | *(abstract)* Given an offloaded tensor, returns the onloaded version (with slicing). |
 | `offload(tensor)` | *(abstract)* Given a tensor, offloads it to the storage device and returns a reference. |
 | `update_offload(offloaded, data)` | *(abstract)* In-place update of an already-offloaded tensor without creating a new storage location. |
 | `__getitem__(key)` | Onloads the tensor. Uses the onloaded cache if `offloading_disabled` is set. |

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -143,10 +143,11 @@ class OffloadCache(MutableMapping, ABC):
             assert str(offload_device) == str(self.offload_device)
 
     @abstractmethod
-    def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
+    def onload(self, key: str, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """
         Given an offloaded tensor, returns that tensor after onloading
 
+        :param key: parameter name (used to retrieve slicing information)
         :param offloaded: offloaded tensor
         :return: onloaded tensor
         """
@@ -196,11 +197,7 @@ class OffloadCache(MutableMapping, ABC):
             return self.keep_onloaded_values[offloaded]
 
         # onload value
-        onloaded = self.onload(offloaded)
-
-        # apply slice data
-        if key in self.slices:
-            onloaded = onloaded.as_strided(*self.slices[key])
+        onloaded = self.onload(key, offloaded)
 
         # when offloading is disabled, populate cache
         if self.offloading_disabled:

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -3,11 +3,14 @@
 
 import contextlib
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from collections.abc import Hashable, MutableMapping
+from types import EllipsisType
 from typing import ClassVar, Literal
 
 import torch
 import torch.distributed as dist
+from compressed_tensors.offload.utils import index_from_view
 from compressed_tensors.utils import is_accelerator_type
 
 
@@ -45,8 +48,9 @@ class OffloadCache(MutableMapping, ABC):
     # offloaded tensors -> onloaded tensors (only when offloading is disabled)
     keep_onloaded_values: ClassVar[dict[torch.Tensor, torch.Tensor]] = dict()
 
-    # slice information
-    slices: dict[str, tuple[torch.Size, tuple[int, ...], int | torch.SymInt]]
+    # view information
+    ref_counter: ClassVar[defaultdict[torch.Tensor, int]] = defaultdict(int)
+    view_index: dict[str, tuple[int | slice, ...] | EllipsisType]
 
     @classmethod
     def cls_from_device(
@@ -134,7 +138,7 @@ class OffloadCache(MutableMapping, ABC):
         super().__init__()
         self.onload_device = onload_device
         self.offloaded_values = dict()
-        self.slices = dict()
+        self.view_index = dict()
 
         # Validate offload_device for subclasses with a fixed offload_device
         # (CPUCache, DiskCache). DeviceCache sets offload_device after super().__init__
@@ -217,14 +221,13 @@ class OffloadCache(MutableMapping, ABC):
         """
         # capture slice data
         if value._base is not None:
-            self.slices[key] = (
-                value.size(),
-                value.stride(),
-                value.storage_offset(),
-            )
-            value = value._base
-        elif key in self.slices:
-            del self.slices[key]
+            base, view_index = index_from_view(value)
+            self.view_index[key] = view_index
+            value = base
+        elif key in self.view_index:
+            del self.view_index[key]
+
+        self.ref_counter[value] += 1
 
         # when onloading is disabled, parameters can be access and assigned directly
         if self.onloading_disabled:
@@ -254,9 +257,12 @@ class OffloadCache(MutableMapping, ABC):
         offloaded = self.offloaded_values[key]
         del self.offloaded_values[key]
 
-        # remove strong ref
         if offloaded in self.keep_onloaded_values:
             del self.keep_onloaded_values[offloaded]
+
+        self.ref_counter[offloaded] -= 1
+        if self.ref_counter[offloaded] <= 0:
+            del self.ref_counter[offloaded]
 
     def __contains__(self, key) -> bool:
         return key in self.offloaded_values

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -45,6 +45,9 @@ class OffloadCache(MutableMapping, ABC):
     # offloaded tensors -> onloaded tensors (only when offloading is disabled)
     keep_onloaded_values: ClassVar[dict[torch.Tensor, torch.Tensor]] = dict()
 
+    # slice information
+    slices: dict[str, tuple[torch.Size, tuple[int, ...], int | torch.SymInt]]
+
     @classmethod
     def cls_from_device(
         cls,
@@ -131,6 +134,7 @@ class OffloadCache(MutableMapping, ABC):
         super().__init__()
         self.onload_device = onload_device
         self.offloaded_values = dict()
+        self.slices = dict()
 
         # Validate offload_device for subclasses with a fixed offload_device
         # (CPUCache, DiskCache). DeviceCache sets offload_device after super().__init__
@@ -194,6 +198,10 @@ class OffloadCache(MutableMapping, ABC):
         # onload value
         onloaded = self.onload(offloaded)
 
+        # apply slice data
+        if key in self.slices:
+            onloaded = onloaded.as_strided(*self.slices[key])
+
         # when offloading is disabled, populate cache
         if self.offloading_disabled:
             self.keep_onloaded_values[offloaded] = onloaded
@@ -210,6 +218,17 @@ class OffloadCache(MutableMapping, ABC):
         :param key: name of tensor
         :param value: tensor value to offload
         """
+        # capture slice data
+        if value._base is not None:
+            self.slices[key] = (
+                value.size(),
+                value.stride(),
+                value.storage_offset(),
+            )
+            value = value._base
+        elif key in self.slices:
+            del self.slices[key]
+
         # when onloading is disabled, parameters can be access and assigned directly
         if self.onloading_disabled:
             self.offloaded_values[key] = value

--- a/src/compressed_tensors/offload/cache/cpu.py
+++ b/src/compressed_tensors/offload/cache/cpu.py
@@ -25,8 +25,8 @@ class CPUCache(OffloadCache):
         :param key: cpu tensor to onload
         :return: device tensor
         """
-        if key in self.slices:
-            offloaded = offloaded.as_strided(*self.slices[key])
+        slice = self.view_index.get(key, ...)
+        offloaded = offloaded[slice]
 
         return send_tensors(offloaded, device=self.onload_device, copy=False)
 

--- a/src/compressed_tensors/offload/cache/cpu.py
+++ b/src/compressed_tensors/offload/cache/cpu.py
@@ -25,8 +25,9 @@ class CPUCache(OffloadCache):
         :param key: cpu tensor to onload
         :return: device tensor
         """
-        slice = self.view_index.get(key, ...)
-        offloaded = offloaded[slice]
+        if key in self.view_index:
+            assert offloaded is not None, "attempted to create a view of `None`"
+            offloaded = offloaded[self.view_index[key]]
 
         return send_tensors(offloaded, device=self.onload_device, copy=False)
 

--- a/src/compressed_tensors/offload/cache/cpu.py
+++ b/src/compressed_tensors/offload/cache/cpu.py
@@ -17,13 +17,17 @@ class CPUCache(OffloadCache):
     def __init__(self, onload_device: torch.device | str, offload_device=None):
         super().__init__(onload_device, offload_device=offload_device)
 
-    def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
+    def onload(self, key: str, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """
         Onload a tensor from cpu to device
 
+        :param key: parameter name (used to retrieve slicing information)
         :param key: cpu tensor to onload
         :return: device tensor
         """
+        if key in self.slices:
+            offloaded = offloaded.as_strided(*self.slices[key])
+
         return send_tensors(offloaded, device=self.onload_device, copy=False)
 
     @catch_cpu_mem_error

--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -37,8 +37,8 @@ class DeviceCache(OffloadCache):
         :param key: device tensor to onload
         :return: device tensor
         """
-        if key in self.slices:
-            offloaded = offloaded.as_strided(*self.slices[key])
+        slice = self.view_index.get(key, ...)
+        offloaded = offloaded[slice]
 
         # move because onload_device might be modified after init
         return send_tensors(offloaded, device=self.onload_device, copy=False)

--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -29,13 +29,17 @@ class DeviceCache(OffloadCache):
         else:
             self.offload_device = self.onload_device
 
-    def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
+    def onload(self, key: str, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """
         Typically a no op, except when onload device has been modified
 
+        :param key: parameter name (used to retrieve slicing information)
         :param key: device tensor to onload
         :return: device tensor
         """
+        if key in self.slices:
+            offloaded = offloaded.as_strided(*self.slices[key])
+
         # move because onload_device might be modified after init
         return send_tensors(offloaded, device=self.onload_device, copy=False)
 

--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -37,8 +37,9 @@ class DeviceCache(OffloadCache):
         :param key: device tensor to onload
         :return: device tensor
         """
-        slice = self.view_index.get(key, ...)
-        offloaded = offloaded[slice]
+        if key in self.view_index:
+            assert offloaded is not None, "attempted to create a view of `None`"
+            offloaded = offloaded[self.view_index[key]]
 
         # move because onload_device might be modified after init
         return send_tensors(offloaded, device=self.onload_device, copy=False)

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -75,9 +75,8 @@ class DiskCache(OffloadCache):
             weight_info["safetensors_file"], framework="pt", device=device
         ) as file:
             onloaded = file.get_slice(weight_info["weight_name"])
-            if key in self.slices:
-                onloaded = onloaded.as_strided(*self.slices[key])
-            onloaded = onloaded[...]  # this materializes the tensor from `get_slice`
+            slice = self.view_index.get(key, ...)
+            onloaded = onloaded[slice]  # this materializes the tensor from `get_slice`
             onloaded = to_tensor(onloaded, offloaded)
             onloaded = onloaded.to(getattr(torch, weight_info["dtype"]))
             return onloaded
@@ -125,9 +124,10 @@ class DiskCache(OffloadCache):
         offloaded = self.offloaded_values[key]
         if not self.onloading_disabled:
             file_path = self.index[offloaded]["safetensors_file"]
-            if self._is_ct_file_path(file_path):
-                os.remove(file_path)
-            del self.index[offloaded]
+            if self.ref_counter[offloaded] <= 1:  # delete after via `super()` call
+                if self._is_ct_file_path(file_path):
+                    os.remove(file_path)
+                del self.index[offloaded]
         super().__delitem__(key)
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -57,10 +57,11 @@ class DiskCache(OffloadCache):
         # Resolve relative paths to absolute paths for symlink creation
         self.offload_dir = Path(offload_dir).resolve()
 
-    def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
+    def onload(self, key: str, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """
         Onload a tensor from disk/meta to device
 
+        :param key: parameter name (used to retrieve slicing information)
         :param offloaded: meta tensor to onload
         :return: device tensor, read from disk
         """
@@ -73,7 +74,10 @@ class DiskCache(OffloadCache):
         with safe_open(
             weight_info["safetensors_file"], framework="pt", device=device
         ) as file:
-            onloaded = file.get_slice(weight_info["weight_name"])  # lazily materialize
+            onloaded = file.get_slice(weight_info["weight_name"])
+            if key in self.slices:
+                onloaded = onloaded.as_strided(*self.slices[key])
+            onloaded = onloaded[...]  # this materializes the tensor from `get_slice`
             onloaded = to_tensor(onloaded, offloaded)
             onloaded = onloaded.to(getattr(torch, weight_info["dtype"]))
             return onloaded

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -73,7 +73,7 @@ class DiskCache(OffloadCache):
         with safe_open(
             weight_info["safetensors_file"], framework="pt", device=device
         ) as file:
-            onloaded = file.get_tensor(weight_info["weight_name"])
+            onloaded = file.get_slice(weight_info["weight_name"])  # lazily materialize
             onloaded = to_tensor(onloaded, offloaded)
             onloaded = onloaded.to(getattr(torch, weight_info["dtype"]))
             return onloaded

--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -56,7 +56,7 @@ def load_offloaded_model(
             # Workaround: transformers v5 tie_weights() calls torch.equal() on
             # meta tensors which is unsupported. Since rank 0 broadcasts the real
             # weights, we can safely skip tying on non-rank workers.
-            kwargs.setdefault("tie_word_embeddings", False)
+            # kwargs.setdefault("tie_word_embeddings", False)
 
         # Intercept `auto_offload`: same as "auto", but only cpu/disk are visible
         elif kwargs["device_map"] == "auto_offload":

--- a/src/compressed_tensors/offload/module.py
+++ b/src/compressed_tensors/offload/module.py
@@ -74,11 +74,11 @@ def remove_module_offload(module: torch.nn.Module, onload_tensors: bool = False)
 
         if onload_tensors:
             module._parameters = {
-                name: module._parameters.onload(param)
+                name: module._parameters.onload(name, param)
                 for name, param in module._parameters.offloaded_values.items()
             }
             module._buffers = {
-                name: module._buffers.onload(param)
+                name: module._buffers.onload(name, param)
                 for name, param in module._buffers.offloaded_values.items()
             }
         else:

--- a/src/compressed_tensors/offload/utils.py
+++ b/src/compressed_tensors/offload/utils.py
@@ -5,6 +5,7 @@ import contextlib
 from collections.abc import Container
 from dataclasses import fields, is_dataclass
 from itertools import chain
+from types import EllipsisType
 from typing import TypeVar
 
 import torch
@@ -207,6 +208,43 @@ def to_meta(module: torch.nn.Module) -> None:
             for name, tensor in state_dict.items()
         }
         replace_direct_state_dict(module, meta_state_dict)
+
+
+def index_from_view(
+    tensor: torch.Tensor,
+) -> tuple[torch.Tensor, tuple[int | slice, ...] | EllipsisType]:
+    """
+
+
+    :param tensor: tensor which is a view
+    :return: slice indexing used to get `tensor` from `tensor._base`
+    """
+    base = tensor._base
+    if base is None:
+        return tensor, ...
+
+    assert base.is_contiguous()
+    assert base.ndim == len(base.size()) == len(base.stride())
+    assert tensor.ndim == len(tensor.size()) == len(tensor.stride())
+    assert base.storage_offset() == 0
+
+    offset = tensor.storage_offset()
+    n_index_dims = base.ndim - tensor.ndim
+
+    result: list[int | slice] = []
+
+    for dim, base_stride in enumerate(base.stride()):
+        start, offset = divmod(offset, base_stride)
+
+        if dim < n_index_dims:
+            result.append(start)
+        else:
+            tensor_dim = dim - n_index_dims
+            size = tensor.size(tensor_dim)
+            step = tensor.stride(tensor_dim) // base_stride
+            result.append(slice(start, start + size * step, step))
+
+    return base, tuple(result)
 
 
 @contextlib.contextmanager

--- a/src/compressed_tensors/offload/utils.py
+++ b/src/compressed_tensors/offload/utils.py
@@ -214,10 +214,19 @@ def index_from_view(
     tensor: torch.Tensor,
 ) -> tuple[torch.Tensor, tuple[int | slice, ...] | EllipsisType]:
     """
+    Get the slice indexing used to reconstruct the tensor view
 
+    ```python
+    a = torch.rand(10, 10, 10)
+    b = a[0, ::2, :5]
+    base, index = index_from_view(b)
+
+    assert torch.equal(base, a)
+    assert torch.equal(base[index], b)
+    ```
 
     :param tensor: tensor which is a view
-    :return: slice indexing used to get `tensor` from `tensor._base`
+    :return: base tensor and slice indexing used to get `tensor` from base tensor
     """
     base = tensor._base
     if base is None:

--- a/tests/test_offload/cache/helpers.py
+++ b/tests/test_offload/cache/helpers.py
@@ -36,7 +36,7 @@ def _test_offload(offload_device, onload_device, offload_cache):
 
 def _test_onload(offload_device, onload_device, offload_cache):
     tensor = torch.ones(10, device=onload_device)
-    onloaded = offload_cache.onload(offload_cache.offload(tensor))
+    onloaded = offload_cache.onload("", offload_cache.offload(tensor))
     assert_device_equal(onloaded.device, onload_device)
     assert_tensor_equal(onloaded, tensor, onload_device)
 

--- a/tests/test_offload/test_utils.py
+++ b/tests/test_offload/test_utils.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from compressed_tensors.offload.utils import index_from_view
+
+
+def test_index_from_view():
+    a = torch.rand(10, 10, 10)
+    b = a[0, ::2, :5]
+    base, index = index_from_view(b)
+
+    assert torch.equal(base, a)
+    assert torch.equal(base[index], b)


### PR DESCRIPTION
## Purpose ##
* Support MoE workflows where offloaded tensors can be onloaded as views
  * Writing to the viewed tensors causes them to write a separate and new offload

## Changes ##
* Add `view_index` to `OffloadCache` which tracks the views of each tensor relative to the base tensor
* Add `ref_counter` which counts how many references there are to a base tensor via views. This can replaced by finalizers later if needed
  * This is primarily used by the disk cache to avoid early deletion of viewed base tensors
* Add `key` argument to `OffloadCache.onload` which allows lookup of the view associated with the onloaded tensor

## Disk Offloading Note ##
* It is well documented that using `get_slice` followed by an indexing only loads the necessary memory view from disk, not the entire tensor

## Testing ##
* TODO: more unit testing