### PR TITLE
Update Black target-version to py310

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py36']
+target-version = ['py310']
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
## Summary

The Black formatter target-version in pyproject.toml was set to py36, which is outdated for this project.

## Changes

- Updated `target-version` in `[tool.black]` section from `['py36']` to `['py310']`
- Aligns with the Python 3.10 version used in CI workflows
- Matches the modern Python requirements (torch>=2.10.0 requires Python 3.10+)

## Testing

Verified by inspection - configuration change only. Black will now format code according to Python 3.10 syntax rules.