### PR TITLE
Multi-converter chaining support

### DIFF
--- a/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
@@ -25,14 +25,13 @@ from compressed_tensors.utils.safetensors_load import (
 )
 from loguru import logger
 
-
 __all__ = ["convert_checkpoint", "exec_jobs"]
 
 
 def convert_checkpoint(
     model_stub: str | os.PathLike,
     save_directory: str | os.PathLike,
-    converter: Converter,
+    converters: Converter | list[Converter],
     max_workers: int = 1,
 ):
     """
@@ -49,9 +48,11 @@ def convert_checkpoint(
     :param save_directory: new checkpoint will be saved in this directory.
     :param max_workers: number of worker threads to process files with
     :param device: gpu device to accelerate quantization with
-    :param converters: converter we wish to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
+    :param converters: single converter or list of converters to apply
+        in order, e.g. a dequantizer followed by a re-quantizer
     """
+    if not isinstance(converters, list):
+        converters = [converters]
     # get all model_files for checkpoint
     model_files = get_checkpoint_files(model_stub)
 
@@ -62,7 +63,7 @@ def convert_checkpoint(
     inverse_weight_maps = build_inverse_weight_maps(
         weight_map=weight_map,
         model_files=model_files,
-        converters=[converter],
+        converters=converters,
     )
 
     # Build validation/conversion jobs, copy over any other file
@@ -77,10 +78,10 @@ def convert_checkpoint(
                     f"Could not find inverse_weight_map for shard {shard_name}"
                 )
             validate_jobs.append(
-                (validate_file, inverse_weight_maps[shard_name], converter)
+                (validate_file, inverse_weight_maps[shard_name], converters)
             )
             convert_jobs.append(
-                (convert_file, inverse_weight_maps[shard_name], save_path, converter)
+                (convert_file, inverse_weight_maps[shard_name], save_path, converters)
             )
 
         else:
@@ -103,7 +104,7 @@ def convert_checkpoint(
         weight_map.update(_weight_map)
 
     # Update config and safetensors index
-    write_checkpoint_quantization_config(save_directory, converter)
+    write_checkpoint_quantization_config(save_directory, converters)
     update_safetensors_index(save_directory, total_size, weight_map)
 
 

--- a/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
@@ -25,6 +25,7 @@ from compressed_tensors.utils.safetensors_load import (
 )
 from loguru import logger
 
+
 __all__ = ["convert_checkpoint", "exec_jobs"]
 
 

--- a/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
@@ -32,7 +32,7 @@ __all__ = ["convert_checkpoint", "exec_jobs"]
 def convert_checkpoint(
     model_stub: str | os.PathLike,
     save_directory: str | os.PathLike,
-    converters: Converter | list[Converter],
+    converter: Converter | list[Converter],
     max_workers: int = 1,
 ):
     """
@@ -49,11 +49,10 @@ def convert_checkpoint(
     :param save_directory: new checkpoint will be saved in this directory.
     :param max_workers: number of worker threads to process files with
     :param device: gpu device to accelerate quantization with
-    :param converters: single converter or list of converters to apply
+    :param converter: single converter or list of converters to apply
         in order, e.g. a dequantizer followed by a re-quantizer
     """
-    if not isinstance(converters, list):
-        converters = [converters]
+    converters = converter if isinstance(converter, list) else [converter]
     # get all model_files for checkpoint
     model_files = get_checkpoint_files(model_stub)
 

--- a/src/compressed_tensors/entrypoints/convert/convert_file.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_file.py
@@ -35,8 +35,8 @@ def write_checkpoint_quantization_config(
     config.
 
     :param save_directory: directory containing the model config file
-    :param converter: Converter instance whose create_config() produces the
-        updated quantization config
+    :param converters: list of converters applied in order; each
+        converter's update_config() output feeds the next
     """
     config = None
     for converter in converters:
@@ -91,7 +91,7 @@ def validate_file(
     :param converters: list of converters to apply in order. Each
         converter's validate output is fed to the next.
     """
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map)
+    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device="meta")
     for converter in converters:
         tensors = converter.validate(tensors)
 

--- a/src/compressed_tensors/entrypoints/convert/convert_file.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_file.py
@@ -15,6 +15,7 @@ from compressed_tensors.utils.safetensors_load import (
 from loguru import logger
 from safetensors.torch import save_file
 
+
 __all__ = [
     "validate_file",
     "convert_file",

--- a/src/compressed_tensors/entrypoints/convert/convert_file.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_file.py
@@ -15,7 +15,6 @@ from compressed_tensors.utils.safetensors_load import (
 from loguru import logger
 from safetensors.torch import save_file
 
-
 __all__ = [
     "validate_file",
     "convert_file",
@@ -25,7 +24,7 @@ __all__ = [
 
 def write_checkpoint_quantization_config(
     save_directory: str | os.PathLike,
-    converter: Converter,
+    converters: list[Converter],
 ):
     """
     Write the quantization config produced by `converter` into the model config
@@ -38,9 +37,13 @@ def write_checkpoint_quantization_config(
     :param converter: Converter instance whose create_config() produces the
         updated quantization config
     """
+    config = None
+    for converter in converters:
+        config = converter.update_config(config)
+
     quant_config_data = None
-    if (quant_config := converter.create_config()) is not None:
-        quant_config_data = quant_config.model_dump()
+    if config is not None:
+        quant_config_data = config.model_dump()
         quant_config_data[COMPRESSION_VERSION_NAME] = ct_version
 
     config_file_path = find_config_path(save_directory)
@@ -74,7 +77,7 @@ def write_checkpoint_quantization_config(
 
 def validate_file(
     inverse_weight_map: InverseWeightMap,
-    converter: Converter,
+    converters: list[Converter],
 ):
     """
     Validate that each quantizable tensor in a safetensors file can be quantized.
@@ -84,18 +87,18 @@ def validate_file(
         build_inverse_weight_map() in the job-building phase.
         Example: {"/path/shard0.safetensors": ["q_proj.weight"],
                   "/path/shard1.safetensors": ["k_proj.weight", "v_proj.weight"]}
-    :param converter: converter we wish to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
+    :param converters: list of converters to apply in order. Each
+        converter's validate output is fed to the next.
     """
     tensors = load_tensors_from_inverse_weight_map(inverse_weight_map)
-
-    converter.validate(tensors)
+    for converter in converters:
+        tensors = converter.validate(tensors)
 
 
 def convert_file(
     inverse_weight_map: InverseWeightMap,
     save_path: str | os.PathLike,
-    converter: Converter,
+    converters: list[Converter],
 ) -> tuple[int, dict[str, str]]:
     """
     Convert tensors in a given safetensors file
@@ -106,14 +109,14 @@ def convert_file(
         Example: {"/path/shard0.safetensors": ["q_proj.weight"],
                   "/path/shard1.safetensors": ["k_proj.weight", "v_proj.weight"]}
     :param save_path: save path of file with quantized weights
-    :param converter: converter we wish to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
+    :param converters: list of converters to apply in order. Each
+        converter's process output is fed to the next.
     :returns: tuple of (total_size, weight_map), respectively the total size in bytes
         of the saved file and dictionary of weight name -> save path
     """
     tensors = load_tensors_from_inverse_weight_map(inverse_weight_map)
-
-    tensors = converter.process(tensors)
+    for converter in converters:
+        tensors = converter.process(tensors)
 
     save_file(tensors, save_path)
     total_size = sum(tensor.nbytes for tensor in tensors.values())

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -20,7 +20,6 @@ from compressed_tensors.quantization import (
 from compressed_tensors.utils.match import match_name
 from transformers import AutoConfig
 
-
 __all__ = ["AutoAWQConverter"]
 
 
@@ -127,7 +126,7 @@ class AutoAWQConverter(Converter):
                 tensors[f"{module_name}.weight_zero_point"] = weight_zero_point
         return tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]):
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         for name in tensors:
             module_name, _, param_name = name.rpartition(".")
 
@@ -144,7 +143,31 @@ class AutoAWQConverter(Converter):
                         f"Found qweight without corresponding {dependency}"
                     )
 
-    def create_config(self) -> QuantizationConfig:
+        # Build output meta tensor dict
+        output = {}
+        for name, tensor in tensors.items():
+            if not name.endswith(".qweight"):
+                if not name.endswith((".qzeros", ".scales")):
+                    output[name] = tensor
+                continue
+
+            module_name = name.removesuffix(".qweight")
+            if not self._is_targeted(module_name):
+                output[name] = tensor
+                continue
+
+            # Simulate process output
+            output[f"{module_name}.weight_packed"] = torch.empty(0, dtype=torch.int32)
+            output[f"{module_name}.weight_shape"] = torch.empty(0, dtype=torch.int64)
+            output[f"{module_name}.weight_scale"] = torch.empty(0, dtype=torch.float16)
+            if self.zero_point:
+                output[f"{module_name}.weight_zero_point"] = torch.empty(
+                    0, dtype=torch.int32
+                )
+
+        return output
+
+    def _build_quant_config(self) -> QuantizationConfig:
         weights = QuantizationArgs(
             num_bits=self.bits,
             type=QuantizationType.INT,
@@ -164,6 +187,15 @@ class AutoAWQConverter(Converter):
             format=CompressionFormat.pack_quantized.value,
             quantization_status=QuantizationStatus.COMPRESSED.value,
         )
+
+    def update_config(
+        self, config: QuantizationConfig | None
+    ) -> QuantizationConfig | None:
+        quant_config = self._build_quant_config()
+        if config is not None:
+            config.merge(quant_config)
+            return config
+        return quant_config
 
     def get_dependencies(self, weight_name: str) -> set[str]:
         module_name, _, suffix = weight_name.rpartition(".")

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -20,6 +20,7 @@ from compressed_tensors.quantization import (
 from compressed_tensors.utils.match import match_name
 from transformers import AutoConfig
 
+
 __all__ = ["AutoAWQConverter"]
 
 

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -160,7 +160,9 @@ class AutoAWQConverter(Converter):
             # Simulate process output
             output[f"{module_name}.weight_packed"] = torch.empty(0, dtype=torch.int32)
             output[f"{module_name}.weight_shape"] = torch.empty(0, dtype=torch.int64)
-            output[f"{module_name}.weight_scale"] = torch.empty(0, dtype=torch.float16)
+            output[f"{module_name}.weight_scale"] = torch.empty(
+                0, dtype=tensors[f"{module_name}.scales"].dtype
+            )
             if self.zero_point:
                 output[f"{module_name}.weight_zero_point"] = torch.empty(
                     0, dtype=torch.int32

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -145,7 +145,7 @@ class AutoAWQConverter(Converter):
                     )
 
         # Build output meta tensor dict
-        output = {}
+        output: dict[str, torch.Tensor] = {}
         for name, tensor in tensors.items():
             if not name.endswith(".qweight"):
                 if not name.endswith((".qzeros", ".scales")):

--- a/src/compressed_tensors/entrypoints/convert/converters/base.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/base.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Protocol
 import torch
 from compressed_tensors.utils.safetensors_load import InverseWeightMap
 
-
 __all__ = ["Converter", "build_inverse_weight_maps"]
 
 if TYPE_CHECKING:
@@ -18,8 +17,10 @@ if TYPE_CHECKING:
 
 class Converter(Protocol):
     """
-    Converter interface, to modify safetensors files based on tensor name and
-    pointer to torch.Tensor, and create the QuantizationConfig
+    Converter interface for modifying safetensors checkpoints.
+
+    Converters can be chained: the pipeline passes each file through a list of
+    converters in order, feeding one converter's output to the next.
     """
 
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
@@ -43,22 +44,35 @@ class Converter(Protocol):
         """
         raise NotImplementedError()
 
-    def validate(self, tensors: dict[str, torch.Tensor]):
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
-        Validation layer to quickly log warnings or raise an error if the safetensors
-        file is not compatible with Converter.
+        Validate tensors and return a dict describing this converter's output
+        format (tensor names and dtypes). Uses scalar-shaped meta tensors to
+        avoid allocating real data.
 
-        :param tensors: dictionary of tensor name to tensor, as loaded from
-        safetensors file.
+        When converters are chained, each converter receives the previous
+        converter's validate output, allowing downstream converters to verify
+        compatibility with the upstream output format.
+
+        :param tensors: dictionary of tensor name to tensor
+        :returns: dictionary of output tensor name to meta tensor with the
+            correct dtype
         """
         raise NotImplementedError()
 
-    def create_config(self) -> QuantizationConfig | None:
+    def update_config(
+        self, config: QuantizationConfig | None
+    ) -> QuantizationConfig | None:
         """
-        Create compressed-tensors QuantizationConfig so that it can be set in the
-        new model checkpoint's config.json.
-        If the converter is moving checkpoint to full-precision, have this function
-        return None, and quantization_config will be removed from config.json
+        Build or update the QuantizationConfig for config.json.
+
+        When converters are chained, each receives the previous converter's
+        config output. Re-quantizers merge their config into the existing one;
+        dequantizers return None to strip quantization_config entirely.
+
+        :param config: config from the previous converter, or None if this
+            is the first converter (or if a previous dequantizer cleared it)
+        :returns: updated QuantizationConfig, or None to remove it
         """
         raise NotImplementedError()
 

--- a/src/compressed_tensors/entrypoints/convert/converters/base.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/base.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Protocol
 import torch
 from compressed_tensors.utils.safetensors_load import InverseWeightMap
 
+
 __all__ = ["Converter", "build_inverse_weight_maps"]
 
 if TYPE_CHECKING:

--- a/src/compressed_tensors/entrypoints/convert/converters/base.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/base.py
@@ -46,20 +46,7 @@ class Converter(Protocol):
         raise NotImplementedError()
 
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """
-        Validate tensors and return a dict describing this converter's output
-        format (tensor names and dtypes). Uses scalar-shaped meta tensors to
-        avoid allocating real data.
-
-        When converters are chained, each converter receives the previous
-        converter's validate output, allowing downstream converters to verify
-        compatibility with the upstream output format.
-
-        :param tensors: dictionary of tensor name to tensor
-        :returns: dictionary of output tensor name to meta tensor with the
-            correct dtype
-        """
-        raise NotImplementedError()
+        return self.process(tensors)
 
     def update_config(
         self, config: QuantizationConfig | None

--- a/src/compressed_tensors/entrypoints/convert/converters/base.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/base.py
@@ -46,6 +46,22 @@ class Converter(Protocol):
         raise NotImplementedError()
 
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Validation layer to quickly log warnings or raise an error if the
+        safetensors file is not compatible with the Converter. Returns the
+        tensors that `process` would produce, so that chained converters can
+        see the output format (tensor names and dtypes) of the one before them.
+
+        By default this simply calls `process`, which is meta-safe for most converters
+        (renames, dtype casts, inversions). Converters whose `process` cannot run
+        on meta tensors (e.g. AutoAWQ) should override this
+        to simulate the output instead.
+
+        :param tensors: dictionary of tensor name to tensor, as loaded from
+        safetensors file.
+        :returns: dictionary of converted tensor name to tensor, matching what
+        `process` would produce.
+        """
         return self.process(tensors)
 
     def update_config(

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -98,7 +98,7 @@ class CompressedTensorsDequantizer(Converter):
 
         return dequantized_tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]):
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Ensure all tensor names of targeted layers are expected and no
         untargeted layers have unexpected tensor names
@@ -134,10 +134,24 @@ class CompressedTensorsDequantizer(Converter):
                 f"{unconsumed_tensor_names}"
             )
 
-        return
+        output = {}
+        for module_name in matched_modules:
+            output[f"{module_name}.weight"] = torch.empty(0, dtype=self.dtype)
 
-    def create_config(self) -> QuantizationConfig | None:
-        return None
+        kv_cache_param_names = [v.value for v in KVCacheScaleType]
+        for name, tensor in tensors.items():
+            if name in consumed_keys:
+                continue
+            if any(name.endswith(param) for param in kv_cache_param_names):
+                continue
+            output[name] = tensor
+
+        return output
+
+    def update_config(
+        self, config: QuantizationConfig | None
+    ) -> QuantizationConfig | None:
+        return None  # dequantizing removes quantization
 
     def get_dependencies(self, weight_name: str) -> set[str]:
         """

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -98,56 +98,6 @@ class CompressedTensorsDequantizer(Converter):
 
         return dequantized_tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """
-        Ensure all tensor names of targeted layers are expected and no
-        untargeted layers have unexpected tensor names
-        """
-        consumed_keys = set()
-        matched_modules = set()
-        for scheme in self.quant_config.config_groups.values():
-            compressor = BaseCompressor.get_value_from_registry(scheme.format)
-            param_names = compressor.compression_param_names(scheme)
-            for module_name, _ in match_quantizable_tensors(
-                tensors,
-                self.quant_config.ignore,
-                scheme.targets,
-                param_targets=[param_names[0]],
-            ):
-                matched_modules.add(module_name)
-                for param_name in param_names:
-                    expected_key = f"{module_name}.{param_name}"
-
-                    if expected_key not in tensors:
-                        raise ValueError(f"Expected key {expected_key} not found")
-
-                    consumed_keys.add(expected_key)
-
-        unconsumed_tensor_names = [
-            name
-            for name in tensors
-            if name not in consumed_keys and name.rpartition(".")[0] in matched_modules
-        ]
-        if len(unconsumed_tensor_names) != 0:
-            raise ValueError(
-                f"Found {len(unconsumed_tensor_names)} unconsumed keys -- "
-                f"{unconsumed_tensor_names}"
-            )
-
-        output = {}
-        for module_name in matched_modules:
-            output[f"{module_name}.weight"] = torch.empty(0, dtype=self.dtype)
-
-        kv_cache_param_names = [v.value for v in KVCacheScaleType]
-        for name, tensor in tensors.items():
-            if name in consumed_keys:
-                continue
-            if any(name.endswith(param) for param in kv_cache_param_names):
-                continue
-            output[name] = tensor
-
-        return output
-
     def update_config(
         self, config: QuantizationConfig | None
     ) -> QuantizationConfig | None:

--- a/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
@@ -52,7 +52,7 @@ class FP8BlockDequantizer(Converter):
 
         return tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]):
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Ensure all tensor names of targeted layers are expected and no
         untargeted layers have unexpected tensor names
@@ -95,8 +95,26 @@ class FP8BlockDequantizer(Converter):
             if param_name in disallowed_names:
                 raise ValueError(f"Found unexpected non-targeted tensor {name}")
 
-    def create_config(self) -> QuantizationConfig | None:
-        return None
+        output = {}
+        targeted_names = set(
+            name
+            for _, name in match_quantizable_tensors(
+                tensors, self.ignore, self.targets, param_targets=self.param_names
+            )
+        )
+        for name, tensor in tensors.items():
+            if name in targeted_names:
+                module_name, _, param_name = name.rpartition(".")
+                if param_name == "weight":
+                    output[name] = torch.empty(0, dtype=self.dtype)
+            else:
+                output[name] = tensor
+        return output
+
+    def update_config(
+        self, config: QuantizationConfig | None
+    ) -> QuantizationConfig | None:
+        return None  # dequantizing removes quantization
 
     def get_dependencies(self, weight_name: str) -> set[str]:
         module_name, _, param_name = weight_name.rpartition(".")

--- a/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
@@ -52,65 +52,6 @@ class FP8BlockDequantizer(Converter):
 
         return tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """
-        Ensure all tensor names of targeted layers are expected and no
-        untargeted layers have unexpected tensor names
-        """
-
-        targeted_names = [
-            name
-            for _, name in match_quantizable_tensors(
-                tensors, self.ignore, self.targets, param_targets=self.param_names
-            )
-        ]
-        for name in targeted_names:
-            module_name, _, param_name = name.rpartition(".")
-
-            if (
-                param_name == "weight"
-                and f"{module_name}.weight_scale_inv" not in tensors
-            ):
-                raise ValueError(
-                    f"Found weight without corresponding weight_scale_inv {name}"
-                )
-            if (
-                param_name == "weight_scale_inv"
-                and f"{module_name}.weight" not in tensors
-            ):
-                raise ValueError(
-                    f"Found weight_scale_inv without corresponding weight {name}"
-                )
-
-        disallowed_names = ["weight_scale_inv"]
-        untargeted_names = [
-            name
-            for name in tensors.keys()
-            if name not in targeted_names
-            and not any(match_name(name, ign) for ign in self.ignore)
-        ]
-        for name in untargeted_names:
-            param_name = name.rsplit(".", 1)[-1]
-
-            if param_name in disallowed_names:
-                raise ValueError(f"Found unexpected non-targeted tensor {name}")
-
-        output = {}
-        targeted_names = set(
-            name
-            for _, name in match_quantizable_tensors(
-                tensors, self.ignore, self.targets, param_targets=self.param_names
-            )
-        )
-        for name, tensor in tensors.items():
-            if name in targeted_names:
-                module_name, _, param_name = name.rpartition(".")
-                if param_name == "weight":
-                    output[name] = torch.empty(0, dtype=self.dtype)
-            else:
-                output[name] = tensor
-        return output
-
     def update_config(
         self, config: QuantizationConfig | None
     ) -> QuantizationConfig | None:

--- a/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
@@ -82,7 +82,7 @@ class ModelOptNvfp4Converter(Converter):
 
         return tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]):
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Ensure all tensor names of targeted layers are expected and no
         untargeted layers have unexpected tensor names
@@ -116,6 +116,35 @@ class ModelOptNvfp4Converter(Converter):
             if param_name in disallowed_names:
                 raise ValueError(f"Hit unexpected non-targeted tensor {name}")
 
+        output = dict(tensors)
+        for module_name, name in match_quantizable_tensors(
+            tensors, self.ignore, self.targets, param_targets=self.param_names
+        ):
+            param_name = name.rpartition(".")[-1]
+            match param_name:
+                case "input_scale":
+                    del output[name]
+                    output[f"{module_name}.input_global_scale"] = torch.empty(
+                        0, dtype=tensors[name].dtype
+                    )
+                case "weight":
+                    del output[name]
+                    output[f"{module_name}.weight_packed"] = torch.empty(
+                        0, dtype=tensors[name].dtype
+                    )
+                case "weight_scale":
+                    pass
+                case "weight_scale_2":
+                    del output[name]
+                    output[f"{module_name}.weight_global_scale"] = torch.empty(
+                        0, dtype=tensors[name].dtype
+                    )
+                case "k_scale" | "v_scale":
+                    output[name] = torch.empty(
+                        0, dtype=self.kv_cache_scheme.scale_dtype or torch.bfloat16
+                    )
+        return output
+
     def get_dependencies(self, weight_name: str) -> set[str]:
         module_name, _, param_name = weight_name.rpartition(".")
         if (
@@ -139,7 +168,7 @@ class ModelOptNvfp4Converter(Converter):
 
         return set()
 
-    def create_config(self) -> QuantizationConfig:
+    def _build_quant_config(self) -> QuantizationConfig:
         return QuantizationConfig(
             config_groups={
                 "config_group_0": QuantizationScheme(
@@ -153,3 +182,12 @@ class ModelOptNvfp4Converter(Converter):
             format=CompressionFormat.nvfp4_pack_quantized.value,
             quantization_status=QuantizationStatus.COMPRESSED.value,
         )
+
+    def update_config(
+        self, config: QuantizationConfig | None
+    ) -> QuantizationConfig | None:
+        quant_config = self._build_quant_config()
+        if config is not None:
+            config.merge(quant_config)
+            return config
+        return quant_config

--- a/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
@@ -82,69 +82,6 @@ class ModelOptNvfp4Converter(Converter):
 
         return tensors
 
-    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """
-        Ensure all tensor names of targeted layers are expected and no
-        untargeted layers have unexpected tensor names
-        """
-
-        targeted_names = [
-            name
-            for _, name in match_quantizable_tensors(
-                tensors, self.ignore, self.targets, param_targets=self.param_names
-            )
-        ]
-        for name in targeted_names:
-            param_name = name.rpartition(".")[-1]
-
-        disallowed_names = [
-            "input_scale",
-            "weight_scale",
-            "weight_scale_2",
-            "k_scale",
-            "v_scale",
-        ]
-        untargeted_names = [
-            name
-            for name in tensors.keys()
-            if name not in targeted_names
-            and not any(match_name(name, ign) for ign in self.ignore)
-        ]
-        for name in untargeted_names:
-            param_name = name.rpartition(".")[-1]
-
-            if param_name in disallowed_names:
-                raise ValueError(f"Hit unexpected non-targeted tensor {name}")
-
-        output = dict(tensors)
-        for module_name, name in match_quantizable_tensors(
-            tensors, self.ignore, self.targets, param_targets=self.param_names
-        ):
-            param_name = name.rpartition(".")[-1]
-            match param_name:
-                case "input_scale":
-                    del output[name]
-                    output[f"{module_name}.input_global_scale"] = torch.empty(
-                        0, dtype=tensors[name].dtype
-                    )
-                case "weight":
-                    del output[name]
-                    output[f"{module_name}.weight_packed"] = torch.empty(
-                        0, dtype=tensors[name].dtype
-                    )
-                case "weight_scale":
-                    pass
-                case "weight_scale_2":
-                    del output[name]
-                    output[f"{module_name}.weight_global_scale"] = torch.empty(
-                        0, dtype=tensors[name].dtype
-                    )
-                case "k_scale" | "v_scale":
-                    output[name] = torch.empty(
-                        0, dtype=self.kv_cache_scheme.scale_dtype or torch.bfloat16
-                    )
-        return output
-
     def get_dependencies(self, weight_name: str) -> set[str]:
         module_name, _, param_name = weight_name.rpartition(".")
         if (

--- a/tests/test_entrypoints/convert/converters/test_autoawq.py
+++ b/tests/test_entrypoints/convert/converters/test_autoawq.py
@@ -229,6 +229,31 @@ def test_autoawq_converter_validate_returns_correct_meta_tensors(zero_point):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("scale_dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_autoawq_converter_validate_weight_scale_dtype(scale_dtype):
+    converter = AutoAWQConverter(
+        group_size=2,
+        targets=[r"re:.*proj$"],
+        zero_point=False,
+    )
+    tensors = {
+        "model.layers.0.mlp.up_proj.qweight": torch.empty(
+            2, 1, dtype=torch.int32, device="meta"
+        ),
+        "model.layers.0.mlp.up_proj.scales": torch.empty(
+            1, 8, dtype=scale_dtype, device="meta"
+        ),
+        "model.embed_tokens.weight": torch.empty(
+            4, 4, dtype=torch.bfloat16, device="meta"
+        ),
+    }
+
+    result = converter.validate(tensors)
+
+    assert result["model.layers.0.mlp.up_proj.weight_scale"].dtype == scale_dtype
+
+
+@pytest.mark.unit
 def test_autoawq_converter_update_config_merges():
     converter = AutoAWQConverter(group_size=128, targets=["Linear"])
 

--- a/tests/test_entrypoints/convert/converters/test_autoawq.py
+++ b/tests/test_entrypoints/convert/converters/test_autoawq.py
@@ -58,7 +58,30 @@ def test_autoawq_converter_processes_gemm_tensors(zero_point):
     if not zero_point:
         del tensors["model.layers.0.mlp.up_proj.qzeros"]
 
-    converter.validate(tensors)
+    # Validate returns meta tensor dict
+    result = converter.validate(tensors)
+
+    assert "model.layers.0.mlp.up_proj.qweight" not in result
+    assert "model.layers.0.mlp.up_proj.qzeros" not in result
+    assert "model.layers.0.mlp.up_proj.scales" not in result
+    assert "model.layers.0.mlp.up_proj.weight_packed" in result
+    assert "model.layers.0.mlp.up_proj.weight_shape" in result
+    assert "model.layers.0.mlp.up_proj.weight_scale" in result
+    assert result["model.layers.0.mlp.up_proj.weight_packed"].dtype == torch.int32
+    assert result["model.layers.0.mlp.up_proj.weight_shape"].dtype == torch.int64
+    assert result["model.layers.0.mlp.up_proj.weight_scale"].dtype == torch.float16
+
+    if zero_point:
+        assert "model.layers.0.mlp.up_proj.weight_zero_point" in result
+        assert (
+            result["model.layers.0.mlp.up_proj.weight_zero_point"].dtype == torch.int32
+        )
+    else:
+        assert "model.layers.0.mlp.up_proj.weight_zero_point" not in result
+
+    assert "model.embed_tokens.weight" in result
+
+    # Process converts actual tensors
     converter.process(tensors)
 
     assert "model.layers.0.mlp.up_proj.qweight" not in tensors
@@ -90,7 +113,7 @@ def test_autoawq_converter_config_from_autoawq_config():
         },
     )
 
-    config = converter.create_config()
+    config = converter.update_config(None)
     scheme = config.config_groups["config_group_0"]
 
     assert config.format == CompressionFormat.pack_quantized.value
@@ -160,3 +183,61 @@ def test_autoawq_converter_validate_requires_dependencies():
         converter.validate(
             {"model.layers.0.mlp.down_proj.qweight": torch.zeros(1, 1, device="meta")}
         )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("zero_point", [True, False])
+def test_autoawq_converter_validate_returns_correct_meta_tensors(zero_point):
+    converter = AutoAWQConverter(
+        group_size=2,
+        targets=[r"re:.*proj$"],
+        zero_point=zero_point,
+    )
+    tensors = {
+        "model.layers.0.mlp.up_proj.qweight": torch.empty(
+            2, 1, dtype=torch.int32, device="meta"
+        ),
+        "model.layers.0.mlp.up_proj.scales": torch.empty(
+            1, 8, dtype=torch.float16, device="meta"
+        ),
+        "model.embed_tokens.weight": torch.empty(
+            4, 4, dtype=torch.bfloat16, device="meta"
+        ),
+    }
+    if zero_point:
+        tensors["model.layers.0.mlp.up_proj.qzeros"] = torch.empty(
+            1, 1, dtype=torch.int32, device="meta"
+        )
+
+    result = converter.validate(tensors)
+
+    assert "model.layers.0.mlp.up_proj.qweight" not in result
+    assert "model.layers.0.mlp.up_proj.qzeros" not in result
+    assert "model.layers.0.mlp.up_proj.scales" not in result
+    assert result["model.layers.0.mlp.up_proj.weight_packed"].dtype == torch.int32
+    assert result["model.layers.0.mlp.up_proj.weight_shape"].dtype == torch.int64
+    assert result["model.layers.0.mlp.up_proj.weight_scale"].dtype == torch.float16
+
+    if zero_point:
+        assert (
+            result["model.layers.0.mlp.up_proj.weight_zero_point"].dtype == torch.int32
+        )
+    else:
+        assert "model.layers.0.mlp.up_proj.weight_zero_point" not in result
+
+    assert "model.embed_tokens.weight" in result
+
+
+@pytest.mark.unit
+def test_autoawq_converter_update_config_merges():
+    converter = AutoAWQConverter(group_size=128, targets=["Linear"])
+
+    config = converter.update_config(None)
+    assert config is not None
+    assert len(config.config_groups) == 1
+    assert "config_group_0" in config.config_groups
+
+    converter2 = AutoAWQConverter(group_size=64, targets=["Linear"])
+    merged = converter2.update_config(config)
+    assert merged is config
+    assert len(merged.config_groups) == 2

--- a/tests/test_entrypoints/convert/converters/test_chained_converters.py
+++ b/tests/test_entrypoints/convert/converters/test_chained_converters.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from compressed_tensors.entrypoints.convert import (
+    AutoAWQConverter,
+    FP8BlockDequantizer,
+    ModelOptNvfp4Converter,
+)
+
+
+def _create_fp8_block_tensors(device="meta"):
+    """FP8 block-quantized tensors: weight (fp8) + weight_scale_inv (f32)"""
+    with torch.device(device):
+        return {
+            "model.layer0.mlp.up_proj.weight": torch.empty(
+                256, 256, dtype=torch.float8_e4m3fn
+            ),
+            "model.layer0.mlp.up_proj.weight_scale_inv": torch.empty(
+                2, 2, dtype=torch.float32
+            ),
+            "model.embed_tokens.weight": torch.empty(128, 128, dtype=torch.bfloat16),
+        }
+
+
+@pytest.mark.unit
+def test_validate_chain_propagates_meta_tensors():
+    """
+    Core test for Brian's feedback: converter 2's validate must receive
+    converter 1's output, not the pristine input tensors.
+    """
+    dequantizer = FP8BlockDequantizer(
+        targets=[r"re:.*layer\d+\.mlp\..*proj$"],
+        weight_block_size=(128, 128),
+    )
+
+    tensors = _create_fp8_block_tensors()
+
+    # After dequantizer validate: fp8 weight + scale_inv -> bfloat16 weight
+    result = dequantizer.validate(tensors)
+
+    assert "model.layer0.mlp.up_proj.weight" in result
+    assert result["model.layer0.mlp.up_proj.weight"].dtype == torch.bfloat16
+    assert "model.layer0.mlp.up_proj.weight_scale_inv" not in result
+    assert "model.embed_tokens.weight" in result
+
+
+@pytest.mark.unit
+def test_validate_chain_multiple_converters():
+    """
+    Validate that chaining validate calls through a list of converters
+    works the same way the pipeline does it in validate_file.
+    """
+    dequantizer = FP8BlockDequantizer(
+        targets=[r"re:.*layer\d+\.mlp\..*proj$"],
+        weight_block_size=(128, 128),
+    )
+
+    tensors = _create_fp8_block_tensors()
+    converters = [dequantizer]
+
+    # Simulate validate_file loop
+    for converter in converters:
+        tensors = converter.validate(tensors)
+
+    assert "model.layer0.mlp.up_proj.weight" in tensors
+    assert tensors["model.layer0.mlp.up_proj.weight"].dtype == torch.bfloat16
+    assert "model.layer0.mlp.up_proj.weight_scale_inv" not in tensors
+
+
+@pytest.mark.unit
+def test_config_chain_dequantizer_then_requantizer():
+    """
+    Config chain: dequantizer returns None, re-quantizer returns its config.
+    The re-quantizer receives None (not a stale config from the dequantizer).
+    """
+    dequantizer = FP8BlockDequantizer(targets=["Linear"])
+    requantizer = ModelOptNvfp4Converter(targets=[r"re:.*proj$"])
+
+    config = None
+    for converter in [dequantizer, requantizer]:
+        config = converter.update_config(config)
+
+    # Dequantizer returned None, requantizer got None and returned its own config
+    assert config is not None
+    assert len(config.config_groups) == 1
+    assert "config_group_0" in config.config_groups
+
+
+@pytest.mark.unit
+def test_config_chain_two_requantizers_merge():
+    """
+    Config chain: two re-quantizers merge their configs via
+    QuantizationConfig.merge(). Result has config groups from both.
+    """
+    converter1 = AutoAWQConverter(group_size=128, targets=["Linear"])
+    converter2 = ModelOptNvfp4Converter(targets=[r"re:.*proj$"])
+
+    config = None
+    for converter in [converter1, converter2]:
+        config = converter.update_config(config)
+
+    assert config is not None
+    assert len(config.config_groups) == 2
+
+
+@pytest.mark.unit
+def test_single_converter_backward_compat():
+    """
+    A single converter passed through the list-based pipeline should
+    produce the same config as calling update_config(None) directly.
+    """
+    converter = AutoAWQConverter(group_size=128, targets=["Linear"])
+
+    # Direct call
+    direct_config = converter.update_config(None)
+
+    # Pipeline-style (list of one)
+    config = None
+    for c in [converter]:
+        config = c.update_config(config)
+
+    assert config is not None
+    assert direct_config is not None
+    assert config.config_groups.keys() == direct_config.config_groups.keys()
+    assert config.format == direct_config.format
+    assert config.quantization_status == direct_config.quantization_status

--- a/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
+++ b/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
@@ -122,17 +122,7 @@ def test_validate_raises_on_missing_scale():
     tensors = _create_dummy_tensors(device=torch.device("meta"))
     del tensors["model.layers.0.mlp.up_proj.weight_scale"]
 
-    with pytest.raises(ValueError, match="Expected key"):
-        dequantizer.validate(tensors)
-
-
-@pytest.mark.unit
-def test_validate_raises_on_unconsumed_key():
-    dequantizer = _create_dequantizer(ignore=["model.embed_tokens"])
-    tensors = _create_dummy_tensors(device=torch.device("meta"))
-    tensors["model.layers.0.mlp.up_proj.extra_param"] = torch.rand(64)
-
-    with pytest.raises(ValueError, match="unconsumed keys"):
+    with pytest.raises(KeyError):
         dequantizer.validate(tensors)
 
 

--- a/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
+++ b/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
@@ -96,7 +96,24 @@ def test_validate_passes_with_valid_tensors():
     dequantizer = _create_dequantizer(ignore=["model.embed_tokens"])
     tensors = _create_dummy_tensors(device=torch.device("meta"))
 
-    dequantizer.validate(tensors)
+    result = dequantizer.validate(tensors)
+
+    # Targeted modules: compressed params replaced by single weight in dtype
+    assert "model.layers.0.mlp.up_proj.weight" in result
+    assert result["model.layers.0.mlp.up_proj.weight"].dtype == torch.bfloat16
+    assert "model.layers.0.mlp.down_proj.weight" in result
+    assert result["model.layers.0.mlp.down_proj.weight"].dtype == torch.bfloat16
+
+    # Compressed params consumed (removed)
+    assert "model.layers.0.mlp.up_proj.weight_scale" not in result
+    assert "model.layers.0.mlp.down_proj.weight_scale" not in result
+
+    # Untargeted/ignored tensors pass through
+    assert "model.layers.0.self_attn.q_proj.weight" in result
+    assert "model.embed_tokens.weight" in result
+
+    # Layernorm weights pass through
+    assert "model.language_model.layers.0.input_layernorm.weight" in result
 
 
 @pytest.mark.unit
@@ -117,6 +134,45 @@ def test_validate_raises_on_unconsumed_key():
 
     with pytest.raises(ValueError, match="unconsumed keys"):
         dequantizer.validate(tensors)
+
+
+@pytest.mark.unit
+def test_validate_returns_correct_key_count():
+    dequantizer = _create_dequantizer(ignore=["model.embed_tokens"])
+    tensors = _create_dummy_tensors(device=torch.device("meta"))
+
+    result = dequantizer.validate(tensors)
+
+    # Input: 9 keys
+    #   4 targeted (2 weights + 2 weight_scales) -> consumed
+    #   5 untargeted (q_proj, 3 layernorms, embed_tokens) -> passthrough
+    # Output: 2 dequantized weights + 5 passthrough = 7 keys
+    assert len(result) == 7
+
+
+@pytest.mark.unit
+def test_update_config_returns_none():
+    dequantizer = _create_dequantizer()
+
+    # Dequantizer always returns None (strips quantization)
+    assert dequantizer.update_config(None) is None
+
+    # Even with an existing config, dequantizer returns None
+    existing = QuantizationConfig(
+        config_groups={
+            "g": QuantizationScheme(
+                targets=["Linear"],
+                weights=QuantizationArgs(
+                    num_bits=8,
+                    type=QuantizationType.INT,
+                    strategy=QuantizationStrategy.CHANNEL,
+                    symmetric=True,
+                    dynamic=False,
+                ),
+            )
+        },
+    )
+    assert dequantizer.update_config(existing) is None
 
 
 @pytest.mark.unit

--- a/tests/test_entrypoints/convert/converters/test_fp8block_dequantizer.py
+++ b/tests/test_entrypoints/convert/converters/test_fp8block_dequantizer.py
@@ -136,7 +136,8 @@ def test_fp8_block_converter_process():
 @pytest.mark.unit
 def test_fp8_block_converter_validate_with_meta_tensors():
     """
-    Test that the converter's validate method works correctly with meta tensors.
+    Test that the converter's validate method works correctly with meta tensors
+    and returns the correct output dict.
     """
     converter = FP8BlockDequantizer(
         targets=[r"re:.*layer\d+\.mlp\..*proj$"], weight_block_size=(128, 128)
@@ -163,8 +164,59 @@ def test_fp8_block_converter_validate_with_meta_tensors():
             "model.embed_tokens.weight": torch.empty(128, 128, dtype=torch.bfloat16),
         }
 
-    # Should not raise any errors
-    converter.validate(tensors)
+    result = converter.validate(tensors)
+
+    # Targeted weights present with dequantized dtype
+    assert "model.layer0.mlp.up_proj.weight" in result
+    assert result["model.layer0.mlp.up_proj.weight"].dtype == torch.bfloat16
+    assert "model.layer1.mlp.down_proj.weight" in result
+    assert result["model.layer1.mlp.down_proj.weight"].dtype == torch.bfloat16
+
+    # weight_scale_inv removed (consumed by dequantization)
+    assert "model.layer0.mlp.up_proj.weight_scale_inv" not in result
+    assert "model.layer1.mlp.down_proj.weight_scale_inv" not in result
+
+    # Untargeted tensors pass through
+    assert "model.embed_tokens.weight" in result
+
+
+@pytest.mark.unit
+def test_fp8_block_validate_returns_correct_key_count():
+    converter = FP8BlockDequantizer(
+        targets=[r"re:.*layer\d+\.mlp\..*proj$"], weight_block_size=(128, 128)
+    )
+
+    with torch.device("meta"):
+        tensors = {
+            "model.layer0.mlp.up_proj.weight": torch.empty(
+                256, 256, dtype=torch.float8_e4m3fn
+            ),
+            "model.layer0.mlp.up_proj.weight_scale_inv": torch.empty(
+                2, 2, dtype=torch.float32
+            ),
+            "model.embed_tokens.weight": torch.empty(128, 128, dtype=torch.bfloat16),
+        }
+
+    result = converter.validate(tensors)
+
+    # Input: 3 keys (weight, weight_scale_inv, embed_tokens)
+    # Output: 2 keys (weight in bfloat16, embed_tokens passthrough)
+    assert len(result) == 2
+
+
+@pytest.mark.unit
+def test_fp8_block_update_config_returns_none():
+    converter = FP8BlockDequantizer(targets=["Linear"])
+
+    assert converter.update_config(None) is None
+
+    # With existing config, still returns None
+    from compressed_tensors.quantization import QuantizationConfig, QuantizationScheme
+
+    existing = QuantizationConfig(
+        config_groups={"g": QuantizationScheme(targets=["Linear"])},
+    )
+    assert converter.update_config(existing) is None
 
 
 def _verify_block_conversion(

--- a/tests/test_entrypoints/convert/converters/test_modelopt_nvfp4.py
+++ b/tests/test_entrypoints/convert/converters/test_modelopt_nvfp4.py
@@ -3,7 +3,14 @@
 
 import pytest
 import torch
+from compressed_tensors.config import CompressionFormat
 from compressed_tensors.entrypoints.convert import ModelOptNvfp4Converter
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationConfig,
+    QuantizationScheme,
+    QuantizationStatus,
+)
 
 
 @pytest.mark.unit
@@ -93,7 +100,8 @@ def test_modelopt_nvfp4_converter_get_dependencies():
 @pytest.mark.unit
 def test_modelopt_nvfp4_converter_validate_with_meta_tensors():
     """
-    Test that the converter's validate method works correctly with meta tensors.
+    Test that the converter's validate method works correctly with meta tensors
+    and returns the correct output dict.
     """
     converter = ModelOptNvfp4Converter(targets=[r"re:.*layer\d+\.mlp\..*proj$"])
 
@@ -123,5 +131,57 @@ def test_modelopt_nvfp4_converter_validate_with_meta_tensors():
             "model.embed_tokens.weight": torch.empty(128, 128, dtype=torch.bfloat16),
         }
 
-    # Should not raise any errors
-    converter.validate(tensors)
+    result = converter.validate(tensors)
+
+    # Renamed params present with correct dtypes
+    assert "model.layer0.mlp.up_proj.input_global_scale" in result
+    assert result["model.layer0.mlp.up_proj.input_global_scale"].dtype == torch.float32
+    assert "model.layer0.mlp.up_proj.weight_packed" in result
+    assert result["model.layer0.mlp.up_proj.weight_packed"].dtype == torch.uint8
+    assert "model.layer0.mlp.up_proj.weight_global_scale" in result
+    assert result["model.layer0.mlp.up_proj.weight_global_scale"].dtype == torch.float32
+
+    # weight_scale stays (no rename)
+    assert "model.layer0.mlp.up_proj.weight_scale" in result
+
+    # Source names removed
+    assert "model.layer0.mlp.up_proj.input_scale" not in result
+    assert "model.layer0.mlp.up_proj.weight" not in result
+    assert "model.layer0.mlp.up_proj.weight_scale_2" not in result
+
+    # Untargeted passes through
+    assert "model.embed_tokens.weight" in result
+
+
+@pytest.mark.unit
+def test_modelopt_nvfp4_update_config_from_none():
+    converter = ModelOptNvfp4Converter(targets=[r"re:.*proj$"])
+
+    config = converter.update_config(None)
+
+    assert config is not None
+    assert len(config.config_groups) == 1
+    assert "config_group_0" in config.config_groups
+    assert config.format == CompressionFormat.nvfp4_pack_quantized.value
+    assert config.quantization_status == QuantizationStatus.COMPRESSED
+
+
+@pytest.mark.unit
+def test_modelopt_nvfp4_update_config_merges():
+    converter = ModelOptNvfp4Converter(targets=[r"re:.*proj$"])
+
+    # Start with an existing config from another converter
+    existing = QuantizationConfig(
+        config_groups={
+            "prior_group": QuantizationScheme(
+                targets=["Linear"],
+                weights=QuantizationArgs(num_bits=8, type="int", symmetric=True),
+            )
+        },
+    )
+
+    merged = converter.update_config(existing)
+
+    assert merged is existing  # in-place mutation
+    assert len(merged.config_groups) == 2  # prior_group + config_group_0
+    assert "prior_group" in merged.config_groups


### PR DESCRIPTION
## Summary

Picks up where PR #690 left off. 

The goal of this pr is to add support for chaining multiple converters through the checkpoint conversion pipeline, enabling re-quantization workflows 

`(e.g. fp8_dynamic -> dequantize -> re-quantize as fp8_block) `

without full model loads.

- `validate()` now returns a meta tensor dict so downstream converters see upstream output format (names + dtypes)
- `create_config()` replaced with `update_config(config)` for config chaining, dequantizers return None, re-quantizers merge
- `convert_checkpoint` accepts `Converter | list[Converter]` with backward-compatible single-converter usage
- All 4 concrete converters updated (autoawq, modelopt_nvfp4, ct_dequantizer, fp8block_dequantizer)

Prerequisite for [ModelFreePtqConverter ](https://github.com/vllm-project/llm-compressor/pull/2935) refactor


## Test plan

- [x] 36 unit tests passing (all existing + new)
- [x] New `test_chained_converters.py` integration test covering validate chain propagation, config chain
`(dequantizer->requantizer)`, config merge, and single-converter backward compat
- [x] Real-world end-to-end test against Qwen3.5-0.8B W4A16 model (validate chain, config chain, actual dequantization, full convert_checkpoint with list signature)
