### PR TITLE
Fix Triton kernel support for non-contiguous x

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -392,8 +392,8 @@ def adapt_scale_and_zp_for_triton(
         scale = scale.unsqueeze(1).expand(num_rows, 1)
     elif scale.shape[0] == 1:
         scale = scale.expand(num_rows, -1)
-    if not scale.is_contiguous():
-        scale = scale.contiguous()
+    scale = scale.contiguous()
+
     if zero_point is not None:
         if zero_point.ndim == 0:
             zero_point = zero_point.expand(num_rows, 1)
@@ -401,8 +401,7 @@ def adapt_scale_and_zp_for_triton(
             zero_point = zero_point.unsqueeze(1).expand(num_rows, 1)
         elif zero_point.shape[0] == 1:
             zero_point = zero_point.expand(num_rows, -1)
-        if not zero_point.is_contiguous():
-            zero_point = zero_point.contiguous()
+        zero_point = zero_point.contiguous()
     return scale, zero_point
 
 

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -53,7 +53,6 @@ def _apply_quantize_op(
         is_fp8 = _needs_fp8(x, scale, zero_point, global_scale, args=args)
         fp8_hw_ok = _is_fp8_supported(x.device) if is_fp8 else True
         do_triton: bool = is_gpu and (not is_fp8 or fp8_hw_ok)
-        # do_triton = False
 
         # Adapt scale/zp for Triton if needed
         if do_triton:

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -252,88 +252,6 @@ if _triton_available:
         q_min_ptr: tl.tensor,
         q_max_ptr: tl.tensor,
         global_scale_ptr: tl.tensor,
-        num_rows,
-        num_cols,
-        group_size,
-        quant_type: tl.constexpr,  # QUANT_TYPE_INT or QUANT_TYPE_FLOAT
-        num_bits: tl.constexpr,  # 4 or 8
-        BLOCK_SIZE_R: tl.constexpr,
-        BLOCK_SIZE_C: tl.constexpr,
-    ):
-        # Set up the pids.
-        pid_r = tl.program_id(axis=0)
-        pid_c = tl.program_id(axis=1)
-        offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-        offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
-        offsets = num_cols * offsets_r[:, None] + offsets_c[None, :]
-
-        masks_r = offsets_r < num_rows
-        masks_c = offsets_c < num_cols
-        masks = masks_r[:, None] & masks_c[None, :]
-
-        scale_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-        scale_offsets_c = (
-            pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
-        ) // group_size
-        scale_offsets = (num_cols // group_size) * scale_offsets_r[
-            :, None
-        ] + scale_offsets_c[None, :]
-        scale_masks_r = scale_offsets_r < num_rows
-        scale_masks_c = scale_offsets_c < num_cols // group_size
-        scale_masks = scale_masks_r[:, None] & scale_masks_c[None, :]
-
-        result_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-        result_offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
-        result_offsets = (
-            num_cols * result_offsets_r[:, None] + result_offsets_c[None, :]
-        )
-
-        result_masks_r = result_offsets_r < num_rows
-        result_masks_c = result_offsets_c < num_cols
-        result_masks = result_masks_r[:, None] & result_masks_c[None, :]
-
-        input = tl.load(input_ptr + offsets, masks, 0.0)
-        scale = tl.load(scale_ptr + scale_offsets, scale_masks, 0.0)
-
-        if global_scale_ptr is not None:
-            global_scale = tl.load(global_scale_ptr)
-            scale = scale / global_scale.to(scale.dtype)
-
-        output = input / scale
-
-        if zero_point_ptr is not None:
-            zero_point = tl.load(zero_point_ptr + scale_offsets, scale_masks, 0.0)
-            output += zero_point
-
-        # clamp and round (equivalent to round_to_quantized_type_args)
-        q_min = tl.load(q_min_ptr)
-        q_max = tl.load(q_max_ptr)
-
-        if quant_type == QUANT_TYPE_INT:
-            output = tl.clamp(output, q_min, q_max)
-            output = tl.extra.cuda.libdevice.rint(output)
-        elif quant_type == QUANT_TYPE_FLOAT:
-            output = tl.clamp(output, q_min, q_max)
-            if num_bits == 4:
-                # Convert to bfloat16 for FP4 rounding (matches CPU path)
-                orig_dtype = output.dtype
-                output = _round_to_fp4(output.to(tl.bfloat16)).to(orig_dtype)
-            elif num_bits == 8:
-                output = output.to(tl.float8e4nv).to(output.dtype)
-
-        tl.store(output_ptr + result_offsets, output, result_masks)
-
-    # This kernel is a bit more expensive to run than the non-strided one,
-    # therefore it is only used when necessary.
-    @triton.jit
-    def _quantize_kernel_strided(
-        output_ptr: tl.tensor,
-        input_ptr: tl.tensor,
-        scale_ptr: tl.tensor,
-        zero_point_ptr: tl.tensor,
-        q_min_ptr: tl.tensor,
-        q_max_ptr: tl.tensor,
-        global_scale_ptr: tl.tensor,
         # Note: unused strides for tensors with fewer dimensions are set to 0.
         input_stride_0,
         input_stride_1,
@@ -354,7 +272,7 @@ if _triton_available:
         BLOCK_SIZE_R: tl.constexpr,
         BLOCK_SIZE_C: tl.constexpr,
     ):
-        """General quantize kernel for non-contiguous tensors using explicit strides.
+        """General quantize kernel using explicit strides.
 
         Handles tensors up to 4D by treating them as a 2D view:
         - row indices span dim_0 * dim_1
@@ -536,13 +454,7 @@ def _quantize(
     )
     num_bits = args.num_bits
 
-    # Check if we need the strided kernel for non-contiguous input tensors
-    use_strided_kernel = not x.is_contiguous()
-
     if args.strategy == QuantizationStrategy.BLOCK:
-        assert (
-            use_strided_kernel
-        ), "BLOCK input should be non-contiguous (from transpose in _process_block)"
         dim_0, dim_1, dim_2, dim_3 = x.shape
         group_size = dim_2 * dim_3  # all col elements share same scale
         num_scale_cols = 1  # one scale per (idx_0, idx_1) pair
@@ -576,78 +488,60 @@ def _quantize(
 
     quantized_value = torch.empty_like(x)
 
-    if use_strided_kernel:
-        x_strides = x.stride()
-        out_strides = quantized_value.stride()
+    x_strides = x.stride()
+    out_strides = quantized_value.stride()
 
-        if args.strategy == QuantizationStrategy.BLOCK:
-            input_stride_0, input_stride_1, input_stride_2, input_stride_3 = x_strides
-            (
-                output_stride_0,
-                output_stride_1,
-                output_stride_2,
-                output_stride_3,
-            ) = out_strides
-        elif args.strategy in (
-            QuantizationStrategy.GROUP,
-            QuantizationStrategy.TENSOR_GROUP,
-        ):
-            input_stride_0 = 0
-            input_stride_1, input_stride_2, input_stride_3 = x_strides
-            output_stride_0 = 0
-            output_stride_1, output_stride_2, output_stride_3 = out_strides
-        else:
-            input_stride_0 = 0
-            input_stride_1, input_stride_3 = x_strides
-            input_stride_2 = 0
-            output_stride_0 = 0
-            output_stride_1, output_stride_3 = out_strides
-            output_stride_2 = 0
-
-        _quantize_kernel_strided[grid](
-            quantized_value,
-            x,
-            scale,
-            zero_point,
-            q_min,
-            q_max,
-            global_scale,
-            input_stride_0,
-            input_stride_1,
-            input_stride_2,
-            input_stride_3,
+    if args.strategy == QuantizationStrategy.BLOCK:
+        input_stride_0, input_stride_1, input_stride_2, input_stride_3 = x_strides
+        (
             output_stride_0,
             output_stride_1,
             output_stride_2,
             output_stride_3,
-            dim_0,
-            dim_1,
-            dim_2,
-            dim_3,
-            group_size,
-            num_scale_cols,
-            quant_type=quant_type,
-            num_bits=num_bits,
-            BLOCK_SIZE_R=block_size_r,
-            BLOCK_SIZE_C=block_size_c,
-        )
+        ) = out_strides
+    elif args.strategy in (
+        QuantizationStrategy.GROUP,
+        QuantizationStrategy.TENSOR_GROUP,
+    ):
+        input_stride_0 = 0
+        input_stride_1, input_stride_2, input_stride_3 = x_strides
+        output_stride_0 = 0
+        output_stride_1, output_stride_2, output_stride_3 = out_strides
     else:
-        _quantize_kernel[grid](
-            quantized_value,
-            x,
-            scale,
-            zero_point,
-            q_min,
-            q_max,
-            global_scale,
-            num_rows,
-            num_cols,
-            group_size,
-            quant_type=quant_type,
-            num_bits=num_bits,
-            BLOCK_SIZE_R=block_size_r,
-            BLOCK_SIZE_C=block_size_c,
-        )
+        input_stride_0 = 0
+        input_stride_1, input_stride_3 = x_strides
+        input_stride_2 = 0
+        output_stride_0 = 0
+        output_stride_1, output_stride_3 = out_strides
+        output_stride_2 = 0
+
+    _quantize_kernel[grid](
+        quantized_value,
+        x,
+        scale,
+        zero_point,
+        q_min,
+        q_max,
+        global_scale,
+        input_stride_0,
+        input_stride_1,
+        input_stride_2,
+        input_stride_3,
+        output_stride_0,
+        output_stride_1,
+        output_stride_2,
+        output_stride_3,
+        dim_0,
+        dim_1,
+        dim_2,
+        dim_3,
+        group_size,
+        num_scale_cols,
+        quant_type=quant_type,
+        num_bits=num_bits,
+        BLOCK_SIZE_R=block_size_r,
+        BLOCK_SIZE_C=block_size_c,
+    )
 
     quantized_value = quantized_value.reshape(original_shape)
 

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -56,29 +56,11 @@ def _apply_quantize_op(
         # do_triton = False
 
         # Adapt scale/zp for Triton if needed
-        if do_triton and args.strategy in (
-            QuantizationStrategy.TENSOR,
-            QuantizationStrategy.CHANNEL,
-        ):
+        if do_triton:
             num_rows = x.shape[0]
             scale, zero_point = adapt_scale_and_zp_for_triton(
                 scale, zero_point, num_rows
             )
-
-        # print("do quantize with:")
-        # print("   x.shape:", x.shape, "x.stride:", x.stride())
-        # print("   scale.shape:", scale.shape, "scale.stride:", scale.stride())
-        # print("   zero_point.shape:", zero_point.shape if zero_point is not None else None, "zero_point.stride:", zero_point.stride() if zero_point is not None else None)
-        # print("   q_min.shape:", q_min.shape, "q_min.stride:", q_min.stride())
-        # print("   q_max.shape:", q_max.shape, "q_max.stride:", q_max.stride())
-        # print("   args:", args)
-        # print("   dtype:", dtype if dtype is not None else None)
-        # print("   global_scale.shape:", global_scale.shape if global_scale is not None else None, "global_scale.stride:", global_scale.stride() if global_scale is not None else None)
-        # print("   do_triton:", do_triton)
-
-        # x = x.contiguous()
-        # scale = scale.contiguous()
-        # zero_point = zero_point.contiguous() if zero_point is not None else None
 
         return _quantize(
             x=x,
@@ -342,6 +324,8 @@ if _triton_available:
 
         tl.store(output_ptr + result_offsets, output, result_masks)
 
+    # This kernel is a bit more expensive to run than the non-strided one,
+    # therefore it is only used when necessary.
     @triton.jit
     def _quantize_kernel_strided(
         output_ptr: tl.tensor,
@@ -351,32 +335,21 @@ if _triton_available:
         q_min_ptr: tl.tensor,
         q_max_ptr: tl.tensor,
         global_scale_ptr: tl.tensor,
-        # Input tensor strides (4D, pad with 0 for fewer dims)
+        # Note: unused strides for tensors with fewer dimensions are set to 0.
         input_stride_0,
         input_stride_1,
         input_stride_2,
         input_stride_3,
-        # Scale tensor strides for each index dimension
-        # scale_offset = idx_0 * scale_stride_idx0 + idx_1 * scale_stride_idx1 + idx_2 * scale_stride_idx2
-        # Set unused strides to 0
-        scale_stride_idx0,
-        scale_stride_idx1,
-        scale_stride_idx2,
-        # Output tensor strides (4D, pad with 0 for fewer dims)
         output_stride_0,
         output_stride_1,
         output_stride_2,
         output_stride_3,
-        # Tensor dimensions (4D shape, pad with 1 for fewer dims)
-        # dims 0,1 make up "rows", dims 2,3 make up "cols"
         dim_0,
         dim_1,
         dim_2,
         dim_3,
-        # Scale dimensions for masking (corresponding to which idx dims are used)
-        scale_dim_0,
-        scale_dim_1,
-        scale_dim_2,
+        group_size,
+        num_scale_cols,
         quant_type: tl.constexpr,  # QUANT_TYPE_INT or QUANT_TYPE_FLOAT
         num_bits: tl.constexpr,  # 4 or 8
         BLOCK_SIZE_R: tl.constexpr,
@@ -388,27 +361,25 @@ if _triton_available:
         - row indices span dim_0 * dim_1
         - col indices span dim_2 * dim_3
 
-        Scale indexing is flexible via scale_stride_idx{0,1,2} parameters:
-        - BLOCK [n_rb, n_cb, bh, bw]: scale indexed by (idx_0, idx_1)
-        - GROUP [1, batch, num_groups, gs]: scale indexed by (idx_1, idx_2)
-        - TENSOR [1, rows, 1, cols]: scale indexed by (idx_1)
+        Scale is expected to be contiguous and indexed linearly as:
+        scale_offset = (idx_0 * dim_1 + idx_1) * num_scale_cols + tile_c // group_size
         """
         pid_r = tl.program_id(axis=0)
         pid_c = tl.program_id(axis=1)
 
-        # Tile indices in the flattened 2D view
         tile_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
         tile_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
 
-        # Convert flattened row index to (idx_0, idx_1)
         idx_0 = tile_r // dim_1
         idx_1 = tile_r % dim_1
 
-        # Convert flattened col index to (idx_2, idx_3)
         idx_2 = tile_c // dim_3
         idx_3 = tile_c % dim_3
 
-        # Compute 4D offsets using actual strides
+        # Compute 2D offset matrices via broadcasting:
+        # - [:, None] reshapes [R] -> [R, 1] (column vector for row indices)
+        # - [None, :] reshapes [C] -> [1, C] (row vector for col indices)
+        # Adding them produces [R, C] matrix of all (row, col) offset combinations
         input_offsets = (
             idx_0[:, None] * input_stride_0
             + idx_1[:, None] * input_stride_1
@@ -423,29 +394,23 @@ if _triton_available:
             + idx_3[None, :] * output_stride_3
         )
 
-        # Scale indexed by combination of idx_0, idx_1, idx_2 (configurable via strides)
-        scale_offsets = (
-            idx_0[:, None] * scale_stride_idx0
-            + idx_1[:, None] * scale_stride_idx1
-            + idx_2[None, :] * scale_stride_idx2
-        )
+        scale_row_idx = idx_0 * dim_1 + idx_1
+        scale_col_idx = tile_c // group_size
+        scale_offsets = scale_row_idx[:, None] * num_scale_cols + scale_col_idx[None, :]
 
-        # Masks for valid indices
         masks_0 = idx_0 < dim_0
         masks_1 = idx_1 < dim_1
         masks_2 = idx_2 < dim_2
         masks_3 = idx_3 < dim_3
-        masks = masks_0[:, None] & masks_1[:, None] & masks_2[None, :] & masks_3[None, :]
+        masks = (
+            masks_0[:, None] & masks_1[:, None] & masks_2[None, :] & masks_3[None, :]
+        )
 
-        # Scale masks for whichever dimensions are used
-        scale_masks_0 = idx_0 < scale_dim_0
-        scale_masks_1 = idx_1 < scale_dim_1
-        scale_masks_2 = idx_2 < scale_dim_2
-        scale_masks = scale_masks_0[:, None] & scale_masks_1[:, None] & scale_masks_2[None, :]
+        num_scale_elements = dim_0 * dim_1 * num_scale_cols
+        scale_masks = scale_offsets < num_scale_elements
 
-        # Load input and scale
         input = tl.load(input_ptr + input_offsets, masks, 0.0)
-        scale = tl.load(scale_ptr + scale_offsets, scale_masks, 0.0)
+        scale = tl.load(scale_ptr + scale_offsets, scale_masks, 1.0)
 
         if global_scale_ptr is not None:
             global_scale = tl.load(global_scale_ptr)
@@ -460,7 +425,6 @@ if _triton_available:
         # clamp and round (equivalent to round_to_quantized_type_args)
         q_min = tl.load(q_min_ptr)
         q_max = tl.load(q_max_ptr)
-
         if quant_type == QUANT_TYPE_INT:
             output = tl.clamp(output, q_min, q_max)
             output = tl.extra.cuda.libdevice.rint(output)
@@ -502,23 +466,26 @@ def adapt_scale_and_zp_for_triton(
     This is required when we use group strategies, so that Triton
     can read the correct scale and zero point for each group.
 
-    Note: We keep scale/zp contiguous because:
-    1. They are small tensors (one value per row/group), so contiguous() is cheap
-    2. The strided kernel focuses on handling large non-contiguous input tensors
+    Note: We keep scale/zp contiguous because they are small tensors
+    (one value per row/group), so contiguous() is cheap
     """
     if scale.ndim == 0:
-        scale = scale.expand(num_rows, 1).contiguous()
+        scale = scale.expand(num_rows, 1)
     elif scale.ndim == 1:
-        scale = scale.unsqueeze(1).expand(num_rows, 1).contiguous()
+        scale = scale.unsqueeze(1).expand(num_rows, 1)
     elif scale.shape[0] == 1:
-        scale = scale.expand(num_rows, -1).contiguous()
+        scale = scale.expand(num_rows, -1)
+    if not scale.is_contiguous():
+        scale = scale.contiguous()
     if zero_point is not None:
         if zero_point.ndim == 0:
-            zero_point = zero_point.expand(num_rows, 1).contiguous()
+            zero_point = zero_point.expand(num_rows, 1)
         elif zero_point.ndim == 1:
-            zero_point = zero_point.unsqueeze(1).expand(num_rows, 1).contiguous()
+            zero_point = zero_point.unsqueeze(1).expand(num_rows, 1)
         elif zero_point.shape[0] == 1:
-            zero_point = zero_point.expand(num_rows, -1).contiguous()
+            zero_point = zero_point.expand(num_rows, -1)
+        if not zero_point.is_contiguous():
+            zero_point = zero_point.contiguous()
     return scale, zero_point
 
 
@@ -552,6 +519,16 @@ def _quantize(
             quantized_ground = quantized_ground.to(dtype)
         return quantized_ground
 
+    assert scale.is_contiguous(), (
+        f"Scale must be contiguous for Triton kernel. "
+        f"Got shape {scale.shape}, stride {scale.stride()}"
+    )
+    if zero_point is not None:
+        assert zero_point.is_contiguous(), (
+            f"Zero point must be contiguous for Triton kernel. "
+            f"Got shape {zero_point.shape}, stride {zero_point.stride()}"
+        )
+
     original_shape = x.shape
 
     # Determine quantization type
@@ -564,33 +541,69 @@ def _quantize(
     use_strided_kernel = not x.is_contiguous()
 
     if args.strategy == QuantizationStrategy.BLOCK:
-        # Block quantization - 4D input with potentially non-contiguous strides
-        n_rb, n_cb, bh, bw = x.shape
-        num_rows = n_rb * n_cb
-        num_cols = bh * bw
+        assert (
+            use_strided_kernel
+        ), "BLOCK input should be non-contiguous (from transpose in _process_block)"
+        dim_0, dim_1, dim_2, dim_3 = x.shape
+        group_size = dim_2 * dim_3  # all col elements share same scale
+        num_scale_cols = 1  # one scale per (idx_0, idx_1) pair
+    elif args.strategy in (
+        QuantizationStrategy.GROUP,
+        QuantizationStrategy.TENSOR_GROUP,
+    ):
+        dim_0 = 1
+        dim_1, dim_2, dim_3 = x.shape
+        group_size = dim_3
+        num_scale_cols = dim_2  # num_groups
+    elif args.strategy in (QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL):
+        dim_0 = 1
+        dim_1, dim_3 = x.shape
+        dim_2 = 1
+        group_size = dim_3  # all cols share same scale
+        num_scale_cols = 1  # one scale per row
+    else:
+        raise ValueError(f"Unsupported quantization strategy: {args.strategy}")
 
-        block_size_r: int = 32
-        block_size_c: int = 32
+    num_rows = dim_0 * dim_1
+    num_cols = dim_2 * dim_3
+    block_size_r: int = 32
+    block_size_c: int = 32
 
-        def grid(META):
-            return (
-                triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
-                triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
-            )
-
-        quantized_value = torch.empty_like(x)
-
-        # Get actual strides for non-contiguous tensor support
-        input_stride_0, input_stride_1, input_stride_2, input_stride_3 = x.stride()
-        output_stride_0, output_stride_1, output_stride_2, output_stride_3 = (
-            quantized_value.stride()
+    def grid(META):
+        return (
+            triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
+            triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
         )
 
-        # BLOCK: scale indexed by (idx_0, idx_1) = (n_rb, n_cb)
-        # scale shape: [n_rb, n_cb, 1, 1]
-        scale_stride_idx0 = scale.stride()[0]
-        scale_stride_idx1 = scale.stride()[1]
-        scale_stride_idx2 = 0  # idx_2 not used for scale
+    quantized_value = torch.empty_like(x)
+
+    if use_strided_kernel:
+        x_strides = x.stride()
+        out_strides = quantized_value.stride()
+
+        if args.strategy == QuantizationStrategy.BLOCK:
+            input_stride_0, input_stride_1, input_stride_2, input_stride_3 = x_strides
+            (
+                output_stride_0,
+                output_stride_1,
+                output_stride_2,
+                output_stride_3,
+            ) = out_strides
+        elif args.strategy in (
+            QuantizationStrategy.GROUP,
+            QuantizationStrategy.TENSOR_GROUP,
+        ):
+            input_stride_0 = 0
+            input_stride_1, input_stride_2, input_stride_3 = x_strides
+            output_stride_0 = 0
+            output_stride_1, output_stride_2, output_stride_3 = out_strides
+        else:
+            input_stride_0 = 0
+            input_stride_1, input_stride_3 = x_strides
+            input_stride_2 = 0
+            output_stride_0 = 0
+            output_stride_1, output_stride_3 = out_strides
+            output_stride_2 = 0
 
         _quantize_kernel_strided[grid](
             quantized_value,
@@ -604,188 +617,40 @@ def _quantize(
             input_stride_1,
             input_stride_2,
             input_stride_3,
-            scale_stride_idx0,
-            scale_stride_idx1,
-            scale_stride_idx2,
             output_stride_0,
             output_stride_1,
             output_stride_2,
             output_stride_3,
-            n_rb,
-            n_cb,
-            bh,
-            bw,
-            scale.shape[0],  # scale_dim_0 for idx_0
-            scale.shape[1],  # scale_dim_1 for idx_1
-            bh,  # scale_dim_2 for idx_2 (always valid since not used)
+            dim_0,
+            dim_1,
+            dim_2,
+            dim_3,
+            group_size,
+            num_scale_cols,
             quant_type=quant_type,
             num_bits=num_bits,
             BLOCK_SIZE_R=block_size_r,
             BLOCK_SIZE_C=block_size_c,
         )
-    elif args.strategy in (
-        QuantizationStrategy.GROUP,
-        QuantizationStrategy.TENSOR_GROUP,
-    ):
-        # Group quantization - 3D input (batch, num_groups, group_size)
-        group_size = x.shape[2]
-        num_rows = x.shape[0]
-        num_cols = x.shape[1] * x.shape[2]
-
-        block_size_r: int = 32
-        block_size_c: int = 32
-
-        def grid(META):
-            return (
-                triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
-                triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
-            )
-
-        quantized_value = torch.empty_like(x)
-
-        if use_strided_kernel:
-            # Use strided kernel for non-contiguous tensors
-            # 3D [batch, num_groups, group_size] -> 4D [1, batch, num_groups, group_size]
-            input_stride_0, input_stride_1, input_stride_2 = x.stride()
-            output_stride_0, output_stride_1, output_stride_2 = quantized_value.stride()
-
-            # GROUP: scale indexed by (idx_1, idx_2) = (batch, num_groups)
-            # scale shape: [batch, num_groups, 1]
-            scale_stride_idx0 = 0  # idx_0 not used (always 0)
-            scale_stride_idx1 = scale.stride()[0]  # batch dimension
-            scale_stride_idx2 = scale.stride()[1]  # num_groups dimension
-
-            _quantize_kernel_strided[grid](
-                quantized_value,
-                x,
-                scale,
-                zero_point,
-                q_min,
-                q_max,
-                global_scale,
-                0,  # input_stride_0 (dim 0 is padded with 1)
-                input_stride_0,
-                input_stride_1,
-                input_stride_2,
-                scale_stride_idx0,
-                scale_stride_idx1,
-                scale_stride_idx2,
-                0,  # output_stride_0 (dim 0 is padded with 1)
-                output_stride_0,
-                output_stride_1,
-                output_stride_2,
-                1,  # dim_0 (padded)
-                x.shape[0],  # dim_1 = batch
-                x.shape[1],  # dim_2 = num_groups
-                x.shape[2],  # dim_3 = group_size
-                1,  # scale_dim_0 for idx_0 (always valid since padded)
-                scale.shape[0],  # scale_dim_1 for idx_1
-                scale.shape[1],  # scale_dim_2 for idx_2
-                quant_type=quant_type,
-                num_bits=num_bits,
-                BLOCK_SIZE_R=block_size_r,
-                BLOCK_SIZE_C=block_size_c,
-            )
-        else:
-            _quantize_kernel[grid](
-                quantized_value,
-                x,
-                scale,
-                zero_point,
-                q_min,
-                q_max,
-                global_scale,
-                num_rows,
-                num_cols,
-                group_size,
-                quant_type=quant_type,
-                num_bits=num_bits,
-                BLOCK_SIZE_R=block_size_r,
-                BLOCK_SIZE_C=block_size_c,
-            )
-
-        quantized_value = quantized_value.reshape(original_shape)
-    elif args.strategy in (QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL):
-        # Tensor/Channel quantization - 2D input
-        group_size = x.shape[1]
-        num_rows = x.shape[0]
-        num_cols = x.shape[1]
-
-        block_size_r: int = 32
-        block_size_c: int = 32
-
-        def grid(META):
-            return (
-                triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
-                triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
-            )
-
-        quantized_value = torch.empty_like(x)
-
-        if use_strided_kernel:
-            # Use strided kernel for non-contiguous tensors
-            # 2D [rows, cols] -> 4D [1, rows, 1, cols]
-            input_stride_0, input_stride_1 = x.stride()
-            output_stride_0, output_stride_1 = quantized_value.stride()
-
-            # TENSOR: scale indexed by idx_1 only (rows)
-            # scale shape: [rows, 1] (after adapt_scale_and_zp_for_triton)
-            scale_stride_idx0 = 0  # idx_0 not used (always 0)
-            scale_stride_idx1 = scale.stride()[0]  # row dimension
-            scale_stride_idx2 = 0  # idx_2 not used (always 0)
-
-            _quantize_kernel_strided[grid](
-                quantized_value,
-                x,
-                scale,
-                zero_point,
-                q_min,
-                q_max,
-                global_scale,
-                0,  # input_stride_0 (dim 0 is padded with 1)
-                input_stride_0,
-                0,  # input_stride_2 (dim 2 is padded with 1)
-                input_stride_1,
-                scale_stride_idx0,
-                scale_stride_idx1,
-                scale_stride_idx2,
-                0,  # output_stride_0 (dim 0 is padded with 1)
-                output_stride_0,
-                0,  # output_stride_2 (dim 2 is padded with 1)
-                output_stride_1,
-                1,  # dim_0 (padded)
-                x.shape[0],  # dim_1 = rows
-                1,  # dim_2 (padded)
-                x.shape[1],  # dim_3 = cols
-                1,  # scale_dim_0 for idx_0 (always valid since padded)
-                scale.shape[0],  # scale_dim_1 for idx_1
-                1,  # scale_dim_2 for idx_2 (always valid since padded)
-                quant_type=quant_type,
-                num_bits=num_bits,
-                BLOCK_SIZE_R=block_size_r,
-                BLOCK_SIZE_C=block_size_c,
-            )
-        else:
-            _quantize_kernel[grid](
-                quantized_value,
-                x,
-                scale,
-                zero_point,
-                q_min,
-                q_max,
-                global_scale,
-                num_rows,
-                num_cols,
-                group_size,
-                quant_type=quant_type,
-                num_bits=num_bits,
-                BLOCK_SIZE_R=block_size_r,
-                BLOCK_SIZE_C=block_size_c,
-            )
-
-        quantized_value = quantized_value.reshape(original_shape)
     else:
-        raise ValueError(f"Unsupported quantization strategy: {args.strategy}")
+        _quantize_kernel[grid](
+            quantized_value,
+            x,
+            scale,
+            zero_point,
+            q_min,
+            q_max,
+            global_scale,
+            num_rows,
+            num_cols,
+            group_size,
+            quant_type=quant_type,
+            num_bits=num_bits,
+            BLOCK_SIZE_R=block_size_r,
+            BLOCK_SIZE_C=block_size_c,
+        )
+
+    quantized_value = quantized_value.reshape(original_shape)
 
     if dtype is not None:
         quantized_value = quantized_value.to(dtype)

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -53,6 +53,7 @@ def _apply_quantize_op(
         is_fp8 = _needs_fp8(x, scale, zero_point, global_scale, args=args)
         fp8_hw_ok = _is_fp8_supported(x.device) if is_fp8 else True
         do_triton: bool = is_gpu and (not is_fp8 or fp8_hw_ok)
+        # do_triton = False
 
         # Adapt scale/zp for Triton if needed
         if do_triton and args.strategy in (
@@ -63,6 +64,21 @@ def _apply_quantize_op(
             scale, zero_point = adapt_scale_and_zp_for_triton(
                 scale, zero_point, num_rows
             )
+
+        # print("do quantize with:")
+        # print("   x.shape:", x.shape, "x.stride:", x.stride())
+        # print("   scale.shape:", scale.shape, "scale.stride:", scale.stride())
+        # print("   zero_point.shape:", zero_point.shape if zero_point is not None else None, "zero_point.stride:", zero_point.stride() if zero_point is not None else None)
+        # print("   q_min.shape:", q_min.shape, "q_min.stride:", q_min.stride())
+        # print("   q_max.shape:", q_max.shape, "q_max.stride:", q_max.stride())
+        # print("   args:", args)
+        # print("   dtype:", dtype if dtype is not None else None)
+        # print("   global_scale.shape:", global_scale.shape if global_scale is not None else None, "global_scale.stride:", global_scale.stride() if global_scale is not None else None)
+        # print("   do_triton:", do_triton)
+
+        # x = x.contiguous()
+        # scale = scale.contiguous()
+        # zero_point = zero_point.contiguous() if zero_point is not None else None
 
         return _quantize(
             x=x,
@@ -326,6 +342,138 @@ if _triton_available:
 
         tl.store(output_ptr + result_offsets, output, result_masks)
 
+    @triton.jit
+    def _quantize_kernel_strided(
+        output_ptr: tl.tensor,
+        input_ptr: tl.tensor,
+        scale_ptr: tl.tensor,
+        zero_point_ptr: tl.tensor,
+        q_min_ptr: tl.tensor,
+        q_max_ptr: tl.tensor,
+        global_scale_ptr: tl.tensor,
+        # Input tensor strides (4D, pad with 0 for fewer dims)
+        input_stride_0,
+        input_stride_1,
+        input_stride_2,
+        input_stride_3,
+        # Scale tensor strides for each index dimension
+        # scale_offset = idx_0 * scale_stride_idx0 + idx_1 * scale_stride_idx1 + idx_2 * scale_stride_idx2
+        # Set unused strides to 0
+        scale_stride_idx0,
+        scale_stride_idx1,
+        scale_stride_idx2,
+        # Output tensor strides (4D, pad with 0 for fewer dims)
+        output_stride_0,
+        output_stride_1,
+        output_stride_2,
+        output_stride_3,
+        # Tensor dimensions (4D shape, pad with 1 for fewer dims)
+        # dims 0,1 make up "rows", dims 2,3 make up "cols"
+        dim_0,
+        dim_1,
+        dim_2,
+        dim_3,
+        # Scale dimensions for masking (corresponding to which idx dims are used)
+        scale_dim_0,
+        scale_dim_1,
+        scale_dim_2,
+        quant_type: tl.constexpr,  # QUANT_TYPE_INT or QUANT_TYPE_FLOAT
+        num_bits: tl.constexpr,  # 4 or 8
+        BLOCK_SIZE_R: tl.constexpr,
+        BLOCK_SIZE_C: tl.constexpr,
+    ):
+        """General quantize kernel for non-contiguous tensors using explicit strides.
+
+        Handles tensors up to 4D by treating them as a 2D view:
+        - row indices span dim_0 * dim_1
+        - col indices span dim_2 * dim_3
+
+        Scale indexing is flexible via scale_stride_idx{0,1,2} parameters:
+        - BLOCK [n_rb, n_cb, bh, bw]: scale indexed by (idx_0, idx_1)
+        - GROUP [1, batch, num_groups, gs]: scale indexed by (idx_1, idx_2)
+        - TENSOR [1, rows, 1, cols]: scale indexed by (idx_1)
+        """
+        pid_r = tl.program_id(axis=0)
+        pid_c = tl.program_id(axis=1)
+
+        # Tile indices in the flattened 2D view
+        tile_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+        tile_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
+
+        # Convert flattened row index to (idx_0, idx_1)
+        idx_0 = tile_r // dim_1
+        idx_1 = tile_r % dim_1
+
+        # Convert flattened col index to (idx_2, idx_3)
+        idx_2 = tile_c // dim_3
+        idx_3 = tile_c % dim_3
+
+        # Compute 4D offsets using actual strides
+        input_offsets = (
+            idx_0[:, None] * input_stride_0
+            + idx_1[:, None] * input_stride_1
+            + idx_2[None, :] * input_stride_2
+            + idx_3[None, :] * input_stride_3
+        )
+
+        output_offsets = (
+            idx_0[:, None] * output_stride_0
+            + idx_1[:, None] * output_stride_1
+            + idx_2[None, :] * output_stride_2
+            + idx_3[None, :] * output_stride_3
+        )
+
+        # Scale indexed by combination of idx_0, idx_1, idx_2 (configurable via strides)
+        scale_offsets = (
+            idx_0[:, None] * scale_stride_idx0
+            + idx_1[:, None] * scale_stride_idx1
+            + idx_2[None, :] * scale_stride_idx2
+        )
+
+        # Masks for valid indices
+        masks_0 = idx_0 < dim_0
+        masks_1 = idx_1 < dim_1
+        masks_2 = idx_2 < dim_2
+        masks_3 = idx_3 < dim_3
+        masks = masks_0[:, None] & masks_1[:, None] & masks_2[None, :] & masks_3[None, :]
+
+        # Scale masks for whichever dimensions are used
+        scale_masks_0 = idx_0 < scale_dim_0
+        scale_masks_1 = idx_1 < scale_dim_1
+        scale_masks_2 = idx_2 < scale_dim_2
+        scale_masks = scale_masks_0[:, None] & scale_masks_1[:, None] & scale_masks_2[None, :]
+
+        # Load input and scale
+        input = tl.load(input_ptr + input_offsets, masks, 0.0)
+        scale = tl.load(scale_ptr + scale_offsets, scale_masks, 0.0)
+
+        if global_scale_ptr is not None:
+            global_scale = tl.load(global_scale_ptr)
+            scale = scale / global_scale.to(scale.dtype)
+
+        output = input / scale
+
+        if zero_point_ptr is not None:
+            zero_point = tl.load(zero_point_ptr + scale_offsets, scale_masks, 0.0)
+            output += zero_point
+
+        # clamp and round (equivalent to round_to_quantized_type_args)
+        q_min = tl.load(q_min_ptr)
+        q_max = tl.load(q_max_ptr)
+
+        if quant_type == QUANT_TYPE_INT:
+            output = tl.clamp(output, q_min, q_max)
+            output = tl.extra.cuda.libdevice.rint(output)
+        elif quant_type == QUANT_TYPE_FLOAT:
+            output = tl.clamp(output, q_min, q_max)
+            if num_bits == 4:
+                orig_dtype = output.dtype
+                output = _round_to_fp4(output.to(tl.bfloat16)).to(orig_dtype)
+            elif num_bits == 8:
+                output = output.to(tl.float8e4nv).to(output.dtype)
+
+        tl.store(output_ptr + output_offsets, output, masks)
+
 
 def _needs_fp8(*tensors, args: QuantizationArgs) -> bool:
     """Check if operation involves FP8 (dtype or quantization type)."""
@@ -351,8 +499,12 @@ def adapt_scale_and_zp_for_triton(
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """
     Adapt scale and zero point for Triton kernel.
-    Thid is required when we use group strategies, so that Triton
+    This is required when we use group strategies, so that Triton
     can read the correct scale and zero point for each group.
+
+    Note: We keep scale/zp contiguous because:
+    1. They are small tensors (one value per row/group), so contiguous() is cheap
+    2. The strided kernel focuses on handling large non-contiguous input tensors
     """
     if scale.ndim == 0:
         scale = scale.expand(num_rows, 1).contiguous()
@@ -402,12 +554,75 @@ def _quantize(
 
     original_shape = x.shape
 
+    # Determine quantization type
+    quant_type = (
+        QUANT_TYPE_INT if args.type == QuantizationType.INT else QUANT_TYPE_FLOAT
+    )
+    num_bits = args.num_bits
+
+    # Check if we need the strided kernel for non-contiguous input tensors
+    use_strided_kernel = not x.is_contiguous()
+
     if args.strategy == QuantizationStrategy.BLOCK:
-        # Block quantization - 4D input
+        # Block quantization - 4D input with potentially non-contiguous strides
         n_rb, n_cb, bh, bw = x.shape
-        group_size = bh * bw
         num_rows = n_rb * n_cb
         num_cols = bh * bw
+
+        block_size_r: int = 32
+        block_size_c: int = 32
+
+        def grid(META):
+            return (
+                triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
+                triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
+            )
+
+        quantized_value = torch.empty_like(x)
+
+        # Get actual strides for non-contiguous tensor support
+        input_stride_0, input_stride_1, input_stride_2, input_stride_3 = x.stride()
+        output_stride_0, output_stride_1, output_stride_2, output_stride_3 = (
+            quantized_value.stride()
+        )
+
+        # BLOCK: scale indexed by (idx_0, idx_1) = (n_rb, n_cb)
+        # scale shape: [n_rb, n_cb, 1, 1]
+        scale_stride_idx0 = scale.stride()[0]
+        scale_stride_idx1 = scale.stride()[1]
+        scale_stride_idx2 = 0  # idx_2 not used for scale
+
+        _quantize_kernel_strided[grid](
+            quantized_value,
+            x,
+            scale,
+            zero_point,
+            q_min,
+            q_max,
+            global_scale,
+            input_stride_0,
+            input_stride_1,
+            input_stride_2,
+            input_stride_3,
+            scale_stride_idx0,
+            scale_stride_idx1,
+            scale_stride_idx2,
+            output_stride_0,
+            output_stride_1,
+            output_stride_2,
+            output_stride_3,
+            n_rb,
+            n_cb,
+            bh,
+            bw,
+            scale.shape[0],  # scale_dim_0 for idx_0
+            scale.shape[1],  # scale_dim_1 for idx_1
+            bh,  # scale_dim_2 for idx_2 (always valid since not used)
+            quant_type=quant_type,
+            num_bits=num_bits,
+            BLOCK_SIZE_R=block_size_r,
+            BLOCK_SIZE_C=block_size_c,
+        )
     elif args.strategy in (
         QuantizationStrategy.GROUP,
         QuantizationStrategy.TENSOR_GROUP,
@@ -416,49 +631,161 @@ def _quantize(
         group_size = x.shape[2]
         num_rows = x.shape[0]
         num_cols = x.shape[1] * x.shape[2]
+
+        block_size_r: int = 32
+        block_size_c: int = 32
+
+        def grid(META):
+            return (
+                triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
+                triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
+            )
+
+        quantized_value = torch.empty_like(x)
+
+        if use_strided_kernel:
+            # Use strided kernel for non-contiguous tensors
+            # 3D [batch, num_groups, group_size] -> 4D [1, batch, num_groups, group_size]
+            input_stride_0, input_stride_1, input_stride_2 = x.stride()
+            output_stride_0, output_stride_1, output_stride_2 = quantized_value.stride()
+
+            # GROUP: scale indexed by (idx_1, idx_2) = (batch, num_groups)
+            # scale shape: [batch, num_groups, 1]
+            scale_stride_idx0 = 0  # idx_0 not used (always 0)
+            scale_stride_idx1 = scale.stride()[0]  # batch dimension
+            scale_stride_idx2 = scale.stride()[1]  # num_groups dimension
+
+            _quantize_kernel_strided[grid](
+                quantized_value,
+                x,
+                scale,
+                zero_point,
+                q_min,
+                q_max,
+                global_scale,
+                0,  # input_stride_0 (dim 0 is padded with 1)
+                input_stride_0,
+                input_stride_1,
+                input_stride_2,
+                scale_stride_idx0,
+                scale_stride_idx1,
+                scale_stride_idx2,
+                0,  # output_stride_0 (dim 0 is padded with 1)
+                output_stride_0,
+                output_stride_1,
+                output_stride_2,
+                1,  # dim_0 (padded)
+                x.shape[0],  # dim_1 = batch
+                x.shape[1],  # dim_2 = num_groups
+                x.shape[2],  # dim_3 = group_size
+                1,  # scale_dim_0 for idx_0 (always valid since padded)
+                scale.shape[0],  # scale_dim_1 for idx_1
+                scale.shape[1],  # scale_dim_2 for idx_2
+                quant_type=quant_type,
+                num_bits=num_bits,
+                BLOCK_SIZE_R=block_size_r,
+                BLOCK_SIZE_C=block_size_c,
+            )
+        else:
+            _quantize_kernel[grid](
+                quantized_value,
+                x,
+                scale,
+                zero_point,
+                q_min,
+                q_max,
+                global_scale,
+                num_rows,
+                num_cols,
+                group_size,
+                quant_type=quant_type,
+                num_bits=num_bits,
+                BLOCK_SIZE_R=block_size_r,
+                BLOCK_SIZE_C=block_size_c,
+            )
+
+        quantized_value = quantized_value.reshape(original_shape)
     elif args.strategy in (QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL):
         # Tensor/Channel quantization - 2D input
         group_size = x.shape[1]
         num_rows = x.shape[0]
         num_cols = x.shape[1]
+
+        block_size_r: int = 32
+        block_size_c: int = 32
+
+        def grid(META):
+            return (
+                triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
+                triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
+            )
+
+        quantized_value = torch.empty_like(x)
+
+        if use_strided_kernel:
+            # Use strided kernel for non-contiguous tensors
+            # 2D [rows, cols] -> 4D [1, rows, 1, cols]
+            input_stride_0, input_stride_1 = x.stride()
+            output_stride_0, output_stride_1 = quantized_value.stride()
+
+            # TENSOR: scale indexed by idx_1 only (rows)
+            # scale shape: [rows, 1] (after adapt_scale_and_zp_for_triton)
+            scale_stride_idx0 = 0  # idx_0 not used (always 0)
+            scale_stride_idx1 = scale.stride()[0]  # row dimension
+            scale_stride_idx2 = 0  # idx_2 not used (always 0)
+
+            _quantize_kernel_strided[grid](
+                quantized_value,
+                x,
+                scale,
+                zero_point,
+                q_min,
+                q_max,
+                global_scale,
+                0,  # input_stride_0 (dim 0 is padded with 1)
+                input_stride_0,
+                0,  # input_stride_2 (dim 2 is padded with 1)
+                input_stride_1,
+                scale_stride_idx0,
+                scale_stride_idx1,
+                scale_stride_idx2,
+                0,  # output_stride_0 (dim 0 is padded with 1)
+                output_stride_0,
+                0,  # output_stride_2 (dim 2 is padded with 1)
+                output_stride_1,
+                1,  # dim_0 (padded)
+                x.shape[0],  # dim_1 = rows
+                1,  # dim_2 (padded)
+                x.shape[1],  # dim_3 = cols
+                1,  # scale_dim_0 for idx_0 (always valid since padded)
+                scale.shape[0],  # scale_dim_1 for idx_1
+                1,  # scale_dim_2 for idx_2 (always valid since padded)
+                quant_type=quant_type,
+                num_bits=num_bits,
+                BLOCK_SIZE_R=block_size_r,
+                BLOCK_SIZE_C=block_size_c,
+            )
+        else:
+            _quantize_kernel[grid](
+                quantized_value,
+                x,
+                scale,
+                zero_point,
+                q_min,
+                q_max,
+                global_scale,
+                num_rows,
+                num_cols,
+                group_size,
+                quant_type=quant_type,
+                num_bits=num_bits,
+                BLOCK_SIZE_R=block_size_r,
+                BLOCK_SIZE_C=block_size_c,
+            )
+
+        quantized_value = quantized_value.reshape(original_shape)
     else:
         raise ValueError(f"Unsupported quantization strategy: {args.strategy}")
-
-    block_size_r: int = 32
-    block_size_c: int = 32
-
-    def grid(META):
-        return (
-            triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
-            triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
-        )
-
-    quantized_value = torch.empty_like(x)
-
-    # Determine quantization type
-    quant_type = (
-        QUANT_TYPE_INT if args.type == QuantizationType.INT else QUANT_TYPE_FLOAT
-    )
-    num_bits = args.num_bits
-
-    _quantize_kernel[grid](
-        quantized_value,
-        x,
-        scale,
-        zero_point,
-        q_min,
-        q_max,
-        global_scale,
-        num_rows,
-        num_cols,
-        group_size,
-        quant_type=quant_type,
-        num_bits=num_bits,
-        BLOCK_SIZE_R=block_size_r,
-        BLOCK_SIZE_C=block_size_c,
-    )
-
-    quantized_value = quantized_value.reshape(original_shape)
 
     if dtype is not None:
         quantized_value = quantized_value.to(dtype)

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -692,7 +692,7 @@ def test_quantize_dequantize_matches_sequential(
     # Adapt scale/zp for Triton if needed (for _quantize only)
     scale_quant = scale.clone()
     zero_point_quant = zero_point.clone() if zero_point is not None else None
-    if do_triton and group_size is None:  # TENSOR strategy
+    if do_triton:
         num_rows = x.shape[0]
         scale_quant, zero_point_quant = adapt_scale_and_zp_for_triton(
             scale_quant, zero_point_quant, num_rows
@@ -814,12 +814,10 @@ def test_quantize_triton_matches_cpu(
     )
     q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
 
-    # Adapt scale/zp for Triton if TENSOR strategy
-    if group_size is None:  # TENSOR strategy
-        num_rows = x_cuda.shape[0]
-        scale_cuda, zero_point_cuda = adapt_scale_and_zp_for_triton(
-            scale_cuda, zero_point_cuda, num_rows
-        )
+    num_rows = x_cuda.shape[0]
+    scale_cuda, zero_point_cuda = adapt_scale_and_zp_for_triton(
+        scale_cuda, zero_point_cuda, num_rows
+    )
 
     # Run CPU (non-Triton) path
     cpu_out = _quantize(
@@ -949,12 +947,11 @@ def test_quantize_triton_matches_cpu_non_contiguous(
 
     assert not x_cuda.is_contiguous(), "CUDA tensor should be non-contiguous"
 
-    # Adapt scale/zp for Triton if TENSOR strategy
-    if group_size is None:
-        num_rows = x_cuda.shape[0]
-        scale_cuda, zero_point_cuda = adapt_scale_and_zp_for_triton(
-            scale_cuda, zero_point_cuda, num_rows
-        )
+    # Adapt scale/zp for Triton
+    num_rows = x_cuda.shape[0]
+    scale_cuda, zero_point_cuda = adapt_scale_and_zp_for_triton(
+        scale_cuda, zero_point_cuda, num_rows
+    )
 
     cpu_out = _quantize(
         x=x_cpu,
@@ -1005,17 +1002,7 @@ def test_quantize_triton_matches_cpu_block_4d(
 ):
     """Verify that the Triton kernel (CUDA) produces identical output
     to the non-Triton (CPU) codepath for _quantize with 4D block quantization.
-
-    Based on failing_args.txt which showed 4D block quantization with
-    non-contiguous tensors created by reshaping 2D matrices into blocks.
-
-    The production code creates these tensors by:
-    1. Starting with a 2D tensor of shape [rows, cols]
-    2. Viewing to [num_block_rows, block_height, num_block_cols, block_width]
-    3. Permuting to [num_block_rows, num_block_cols, block_height, block_width]
-
-    This produces specific non-contiguous strides like (262144, 128, 2048, 1)
-    for shape [16, 16, 128, 128], which differ from simple 4D permutations."""
+    """
     if not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
@@ -1035,41 +1022,30 @@ def test_quantize_triton_matches_cpu_block_4d(
     rows_2d = num_block_rows * bh
     cols_2d = num_block_cols * bw
 
-    # Create tensor exactly as production code does:
-    # 1. Start with 2D contiguous tensor
-    # 2. View to [num_block_rows, block_height, num_block_cols, block_width]
-    # 3. Permute to [num_block_rows, num_block_cols, block_height, block_width]
     x_2d = torch.randn(rows_2d, cols_2d)
     x_cpu = x_2d.view(num_block_rows, bh, num_block_cols, bw).permute(0, 2, 1, 3)
 
-    # Verify we get the expected stride pattern from failing_args.txt
     expected_stride = (bh * cols_2d, bw, cols_2d, 1)
-    assert x_cpu.stride() == expected_stride, (
-        f"Stride mismatch: got {x_cpu.stride()}, expected {expected_stride}"
-    )
+    assert (
+        x_cpu.stride() == expected_stride
+    ), f"Stride mismatch: got {x_cpu.stride()}, expected {expected_stride}"
     assert not x_cpu.is_contiguous(), "Test requires non-contiguous tensor"
 
-    # Scale and zero_point: contiguous [num_block_rows, num_block_cols, 1, 1]
-    # with stride (num_block_cols, 1, 1, 1) as seen in failing_args.txt
     scale_cpu = torch.rand(num_block_rows, num_block_cols, 1, 1) * 0.01 + 0.001
-    zero_point_cpu = torch.zeros(num_block_rows, num_block_cols, 1, 1)
 
     q_min_cpu, q_max_cpu = calculate_range(args, torch.device("cpu"))
 
-    # Copy to CUDA
     x_cuda = x_cpu.cuda()
     scale_cuda = scale_cpu.cuda()
-    zero_point_cuda = zero_point_cpu.cuda()
     q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
 
     assert not x_cuda.is_contiguous(), "CUDA tensor should be non-contiguous"
     assert x_cuda.stride() == expected_stride, "CUDA tensor stride should match"
 
-    # Run CPU (non-Triton) path
     cpu_out = _quantize(
         x=x_cpu,
         scale=scale_cpu,
-        zero_point=zero_point_cpu,
+        zero_point=None,
         q_min=q_min_cpu,
         q_max=q_max_cpu,
         args=args,
@@ -1077,11 +1053,10 @@ def test_quantize_triton_matches_cpu_block_4d(
         do_triton=False,
     )
 
-    # Run CUDA (Triton) path
     cuda_out = _quantize(
         x=x_cuda,
         scale=scale_cuda,
-        zero_point=zero_point_cuda,
+        zero_point=None,
         q_min=q_min_cuda,
         q_max=q_max_cuda,
         args=args,
@@ -1094,7 +1069,9 @@ def test_quantize_triton_matches_cpu_block_4d(
     # FP8 tolerance
     atol, rtol = 1e-5, 0.15
 
-    assert torch.allclose(cpu_out.float(), cuda_out_cpu.float(), atol=atol, rtol=rtol), (
+    assert torch.allclose(
+        cpu_out.float(), cuda_out_cpu.float(), atol=atol, rtol=rtol
+    ), (
         f"Mismatch between CPU and Triton paths (4D block): max diff = "
         f"{(cpu_out.float() - cuda_out_cpu.float()).abs().max().item()}"
     )

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -989,3 +989,112 @@ def test_quantize_triton_matches_cpu_non_contiguous(
         f"Mismatch between CPU and Triton paths (non-contiguous): max diff = "
         f"{(cpu_out - cuda_out_cpu).abs().max().item()}"
     )
+
+
+@pytest.mark.parametrize(
+    "num_block_rows,num_block_cols,block_structure",
+    [
+        (16, 16, [128, 128]),
+        (2, 16, [128, 128]),
+        (44, 16, [128, 128]),
+        (16, 44, [128, 128]),
+    ],
+)
+def test_quantize_triton_matches_cpu_block_4d(
+    num_block_rows, num_block_cols, block_structure
+):
+    """Verify that the Triton kernel (CUDA) produces identical output
+    to the non-Triton (CPU) codepath for _quantize with 4D block quantization.
+
+    Based on failing_args.txt which showed 4D block quantization with
+    non-contiguous tensors created by reshaping 2D matrices into blocks.
+
+    The production code creates these tensors by:
+    1. Starting with a 2D tensor of shape [rows, cols]
+    2. Viewing to [num_block_rows, block_height, num_block_cols, block_width]
+    3. Permuting to [num_block_rows, num_block_cols, block_height, block_width]
+
+    This produces specific non-contiguous strides like (262144, 128, 2048, 1)
+    for shape [16, 16, 128, 128], which differ from simple 4D permutations."""
+    if not torch.accelerator.is_available():
+        pytest.skip("CUDA not available")
+
+    num_bits = 8
+    type_ = "float"
+    symmetric = True
+
+    args = QuantizationArgs(
+        num_bits=num_bits,
+        type=type_,
+        symmetric=symmetric,
+        strategy=QuantizationStrategy.BLOCK,
+        block_structure=block_structure,
+    )
+
+    bh, bw = block_structure
+    rows_2d = num_block_rows * bh
+    cols_2d = num_block_cols * bw
+
+    # Create tensor exactly as production code does:
+    # 1. Start with 2D contiguous tensor
+    # 2. View to [num_block_rows, block_height, num_block_cols, block_width]
+    # 3. Permute to [num_block_rows, num_block_cols, block_height, block_width]
+    x_2d = torch.randn(rows_2d, cols_2d)
+    x_cpu = x_2d.view(num_block_rows, bh, num_block_cols, bw).permute(0, 2, 1, 3)
+
+    # Verify we get the expected stride pattern from failing_args.txt
+    expected_stride = (bh * cols_2d, bw, cols_2d, 1)
+    assert x_cpu.stride() == expected_stride, (
+        f"Stride mismatch: got {x_cpu.stride()}, expected {expected_stride}"
+    )
+    assert not x_cpu.is_contiguous(), "Test requires non-contiguous tensor"
+
+    # Scale and zero_point: contiguous [num_block_rows, num_block_cols, 1, 1]
+    # with stride (num_block_cols, 1, 1, 1) as seen in failing_args.txt
+    scale_cpu = torch.rand(num_block_rows, num_block_cols, 1, 1) * 0.01 + 0.001
+    zero_point_cpu = torch.zeros(num_block_rows, num_block_cols, 1, 1)
+
+    q_min_cpu, q_max_cpu = calculate_range(args, torch.device("cpu"))
+
+    # Copy to CUDA
+    x_cuda = x_cpu.cuda()
+    scale_cuda = scale_cpu.cuda()
+    zero_point_cuda = zero_point_cpu.cuda()
+    q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
+
+    assert not x_cuda.is_contiguous(), "CUDA tensor should be non-contiguous"
+    assert x_cuda.stride() == expected_stride, "CUDA tensor stride should match"
+
+    # Run CPU (non-Triton) path
+    cpu_out = _quantize(
+        x=x_cpu,
+        scale=scale_cpu,
+        zero_point=zero_point_cpu,
+        q_min=q_min_cpu,
+        q_max=q_max_cpu,
+        args=args,
+        global_scale=None,
+        do_triton=False,
+    )
+
+    # Run CUDA (Triton) path
+    cuda_out = _quantize(
+        x=x_cuda,
+        scale=scale_cuda,
+        zero_point=zero_point_cuda,
+        q_min=q_min_cuda,
+        q_max=q_max_cuda,
+        args=args,
+        global_scale=None,
+        do_triton=True,
+    )
+
+    cuda_out_cpu = cuda_out.cpu()
+
+    # FP8 tolerance
+    atol, rtol = 1e-5, 0.15
+
+    assert torch.allclose(cpu_out.float(), cuda_out_cpu.float(), atol=atol, rtol=rtol), (
+        f"Mismatch between CPU and Triton paths (4D block): max diff = "
+        f"{(cpu_out.float() - cuda_out_cpu.float()).abs().max().item()}"
+    )


### PR DESCRIPTION
Addresses the `tests/e2e/test_vllm.py::TestvLLM::test_vllm[tests/e2e/configs/fp8_block.yaml]:291` failure in `llm-compressor` introduced by #777 

Non-contiguous inputs/outputs are now passed to Triton kernels that are aware of their respective strides.

(Made with the use of Claude Opus, all code has been manually reviewed by a human)

### Testing:

#### Unit test:
```
pytest tests/test_quantization/lifecycle/test_forward.py -k test_quantize_triton_matches_cpu_block_4d
```

#### E2E test:
From `llm-compressor`:
```
SKIP_HF_UPLOAD=yes TEST_DATA_FILE=tests/e2e/configs/fp8_block.yaml pytest tests/e2e/test_vllm.py -k test_vllm
```
