### PR TITLE
feat: layerwise decompression/compression support

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -7,7 +7,11 @@ from typing import Optional
 import torch
 from compressed_tensors.compressors.format import infer_module_format
 from compressed_tensors.config import CompressionFormat
-from compressed_tensors.quantization import QuantizationScheme, QuantizationStatus
+from compressed_tensors.quantization import (
+    QuantizationMetadata,
+    QuantizationScheme,
+    QuantizationStatus,
+)
 from compressed_tensors.registry import RegistryMixin
 from compressed_tensors.utils import (
     TensorStateDict,
@@ -112,7 +116,9 @@ class BaseCompressor(RegistryMixin, ABC):
         module.quantization_status = QuantizationStatus.COMPRESSED
 
     @classmethod
-    def decompress_module(cls, module: torch.nn.Module) -> None:
+    def decompress_module(
+        cls, module: torch.nn.Module, leave_decompressed: bool = True
+    ) -> None:
         """
         Decompress a module in-place by decompressing its state dict.
 
@@ -121,6 +127,10 @@ class BaseCompressor(RegistryMixin, ABC):
         version.
 
         :param module: the module to decompress in-place
+        :param leave_decompressed: if True, set quantization_status to DECOMPRESSED
+            after decompression. If False, remove all qparams, quantization_scheme,
+            quantization_status, and restore the original forward method, leaving the
+            module as if quantization had never been applied.
         """
         scheme = getattr(module, "quantization_scheme")
 
@@ -128,7 +138,14 @@ class BaseCompressor(RegistryMixin, ABC):
         decompressed_state_dict = cls.decompress(state_dict, scheme)
         replace_direct_state_dict(module, decompressed_state_dict)
 
-        module.quantization_status = QuantizationStatus.DECOMPRESSED
+        if leave_decompressed:
+            module.quantization_status = QuantizationStatus.DECOMPRESSED
+        else:
+            QuantizationMetadata.clear_quantization(module)
+            if hasattr(module, "quantization_status"):
+                delattr(module, "quantization_status")
+            if hasattr(module, "quantization_scheme"):
+                delattr(module, "quantization_scheme")
 
     @classmethod
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
@@ -194,11 +211,12 @@ def compress_module(
 
 
 def decompress_module(
-    module: torch.nn.Module, format: Optional[CompressionFormat] = None
+    module: torch.nn.Module,
+    format: Optional[CompressionFormat] = None,
+    leave_decompressed: bool = True,
 ):
     """
-    Decompress a module which has had quantization applied to it. Sets the
-    module's quantization format attribute to whichever format was used to decompress.
+    Decompress a module which has had quantization applied to it.
 
     The format used to decompress will be found from one of the following locations:
     1. the `format` argument passed to this function
@@ -207,6 +225,10 @@ def decompress_module(
 
     :param module: module to decompress inplace
     :param format: force override for decompression format
+    :param leave_decompressed: if True (default), set quantization_status to
+        DECOMPRESSED after decompression. If False, remove all qparams,
+        quantization_scheme, quantization_status, and restore the original forward
+        method, leaving the module as if quantization had never been applied.
     """
     scheme = getattr(module, "quantization_scheme", None)
     if not isinstance(scheme, QuantizationScheme):
@@ -216,4 +238,4 @@ def decompress_module(
         format or scheme.format or infer_module_format(type(module), scheme)
     )
     compressor = BaseCompressor.get_value_from_registry(scheme.format.value)
-    compressor.decompress_module(module)
+    compressor.decompress_module(module, leave_decompressed=leave_decompressed)

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -102,6 +102,7 @@ def apply_quantization_config(
     config: QuantizationConfig | None,
     run_compressed: bool = False,
     show_progress: bool = True,
+    allowed_modules: list[Module] | None = None,
 ):
     """
     Initializes the model for quantization in-place based on the given config.
@@ -112,6 +113,9 @@ def apply_quantization_config(
     :param run_compressed: Whether the model will be run in compressed mode or
         decompressed fully on load
     :param show_progress: Whether to show progress bar during quantization
+    :param allowed_modules: optional list of module references to restrict
+        quantization to; when provided, only matched modules that appear
+        in this collection will be quantized
     """
     config = deepcopy(config)
     if config is None:  # see PR #180
@@ -124,7 +128,10 @@ def apply_quantization_config(
     # apply and initialize kv cache quantization
     if config.kv_cache_scheme is not None:
         _apply_kv_cache_scheme(
-            model, config.kv_cache_scheme, config.quantization_status
+            model,
+            config.kv_cache_scheme,
+            config.quantization_status,
+            allowed_modules=allowed_modules,
         )
 
     # build mapping of targets to schemes for easier matching
@@ -135,9 +142,13 @@ def apply_quantization_config(
             target_to_scheme[target] = scheme
 
     # mark appropriate layers for quantization by setting their quantization schemes
-    matched_modules = list(
-        match_named_modules(model, target_to_scheme, config.ignore, warn_on_fail=True)
-    )
+    matched_modules = [
+        (name, module)
+        for name, module in match_named_modules(
+            model, target_to_scheme, config.ignore, warn_on_fail=True
+        )
+        if allowed_modules is None or module in allowed_modules
+    ]
 
     for name, module in tqdm(
         matched_modules,
@@ -173,6 +184,7 @@ def _apply_kv_cache_scheme(
     model: torch.nn.Module,
     kv_cache_scheme: QuantizationArgs,
     status: QuantizationStatus,
+    allowed_modules: list[Module] | None = None,
 ):
     if not kv_cache_scheme.symmetric:
         logger.warning("vLLM does not support asymmetric kv cache quantization")
@@ -185,6 +197,8 @@ def _apply_kv_cache_scheme(
         input_activations=kv_cache_scheme,
     )
     for submodule in model.modules():
+        if allowed_modules is not None and submodule not in allowed_modules:
+            continue
         if is_cached_attention_module(submodule):
             submodule.quantization_scheme = scheme
             initialize_hooked_kv_cache(model, submodule)


### PR DESCRIPTION
## Summary
- Adds `leave_decompressed` parameter to `decompress_module()` — when `False`, strips all quantization metadata (scheme, status, qparams, forward hooks), enabling decompress-then-reapply workflows
- Adds `allowed_modules` parameter to `apply_quantization_config()` and `_apply_kv_cache_scheme()` to restrict quantization initialization to a subset of modules (e.g., a single decoder layer)

These APIs enable layerwise decompression and compression in the sequential pipeline, where each layer can be decompressed, recalibrated, and re-compressed independently.

**Companion PR:** llm-compressor (TBD) integrates these APIs into the sequential pipeline via `layerwise_decompression` / `layerwise_compression` data arguments

## Test plan
- [ ] Verify `decompress_module(leave_decompressed=True)` preserves quantization metadata (existing behavior)
- [ ] Verify `decompress_module(leave_decompressed=False)` fully strips quantization
- [ ] Verify `apply_quantization_config(allowed_modules=...)` only quantizes specified modules
- [ ] Verify round-trip: decompress(leave_decompressed=False) → apply_quantization_config(allowed_modules) → calibrate → compress

🤖 Generated with [Claude Code](https://claude.com/claude-code)