### PR TITLE
Fix import of compressed_tensors when Triton is not installed

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -21,7 +21,6 @@ from compressed_tensors.quantization.quant_args import (
     round_to_quantized_type_args,
 )
 from compressed_tensors.quantization.utils import maybe_pad_tensor_for_block_quant
-from compressed_tensors.quantization.utils.fp4_utils import _round_to_fp4
 
 
 def _apply_quantize_op(
@@ -237,11 +236,14 @@ def _quantize_dequantize(
     return dequant * scale
 
 
-# Quantization type constants for Triton kernel
-QUANT_TYPE_INT = tl.constexpr(0)
-QUANT_TYPE_FLOAT = tl.constexpr(1)
-
 if _triton_available:
+    # `_round_to_fp4` is only defined when Triton is installed, and the constants
+    # below call into `triton.language`, so both must stay behind this guard.
+    from compressed_tensors.quantization.utils.fp4_utils import _round_to_fp4
+
+    # Quantization type constants for Triton kernel
+    QUANT_TYPE_INT = tl.constexpr(0)
+    QUANT_TYPE_FLOAT = tl.constexpr(1)
 
     @triton.jit
     def _quantize_kernel(

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
+import subprocess
+import sys
+import textwrap
 
 import pytest
 import torch
@@ -1074,4 +1077,62 @@ def test_quantize_triton_matches_cpu_block_4d(
     ), (
         f"Mismatch between CPU and Triton paths (4D block): max diff = "
         f"{(cpu_out.float() - cuda_out_cpu.float()).abs().max().item()}"
+    )
+
+
+def test_import_and_quantize_without_triton():
+    """
+    Triton is an optional dependency: it is not in ``install_requires`` and the
+    ``import triton`` at the top of ``forward_helpers`` is wrapped in a
+    try/except. Any Triton-only symbol referenced at module scope therefore
+    makes ``import compressed_tensors`` fail outright on CPU-only installs.
+
+    Run in a subprocess with ``triton`` masked out so the check is meaningful
+    even on machines where Triton happens to be installed.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+
+        class _BlockTriton:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "triton" or fullname.startswith("triton."):
+                    raise ImportError("triton is masked for this test")
+                return None
+
+        for name in list(sys.modules):
+            if name == "triton" or name.startswith("triton."):
+                del sys.modules[name]
+        sys.meta_path.insert(0, _BlockTriton())
+
+        import torch
+        import compressed_tensors  # noqa: F401
+        from compressed_tensors.quantization.lifecycle import forward_helpers
+        from compressed_tensors.quantization.quant_args import QuantizationArgs
+
+        assert forward_helpers._triton_available is False, "triton mask did not take"
+
+        # the pure-torch fallback must still quantize
+        args = QuantizationArgs(
+            num_bits=8, type="int", symmetric=True, strategy="tensor"
+        )
+        out = forward_helpers._quantize(
+            x=torch.tensor([[-1.0, 0.0, 1.0, 2.0]]),
+            scale=torch.tensor(0.05),
+            zero_point=torch.tensor(0),
+            q_min=torch.tensor(-128.0),
+            q_max=torch.tensor(127.0),
+            args=args,
+            do_triton=False,
+        )
+        assert out.shape == (1, 4), out.shape
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        "compressed_tensors must import and quantize without Triton:\n"
+        f"{result.stdout}\n{result.stderr}"
     )


### PR DESCRIPTION
## Summary

`import compressed_tensors` currently raises on any machine that does not have Triton installed, which makes the whole package unusable there. This is a regression from #777.

Triton is an optional dependency. It is not in `install_requires` (that is `torch`, `transformers`, `pydantic`, `loguru`, `psutil`), and both `forward_helpers.py` and `nvfp4/helpers.py` wrap `import triton` in a try/except that sets `_triton_available`. Two module-scope references in `forward_helpers.py` escaped that guard:

1. Line 24 imports `_round_to_fp4` from `fp4_utils` unconditionally, but `fp4_utils` only defines that symbol inside its own `if _triton_available:` block.
2. `QUANT_TYPE_INT` and `QUANT_TYPE_FLOAT` call `tl.constexpr(...)` at module scope, and `tl` only exists when the Triton import succeeded.

Either one alone is enough to break the import.

CI does not catch this because on Linux `pip install torch` pulls Triton in as a transitive dependency, so `_triton_available` is always True there. The failure shows up on macOS, on CPU-only installs, and on any environment where torch ships without Triton.

## Fix

Both symbols are only ever read from Triton code paths. `_round_to_fp4` is used only inside the `@triton.jit` kernel `_quantize_kernel`, and the two constants are only read in `_quantize` after an early return that sends every non-Triton call down the pure torch path. Moving both inside the existing `if _triton_available:` block is therefore sufficient, and it does not change behavior when Triton is present.

## Scope

The regression landed on 2026-07-30 and is not in any released tag yet. `0.17.1` and earlier are clean. It is present on `main` and in the nightly builds, so it reaches users who install a pre-release. llm-compressor picks it up as well: with `compressed-tensors 0.17.2a20260804` from PyPI, `import llmcompressor` fails with the same traceback.

## Verification

Run on macOS arm64, Python 3.14, with no Triton installed.

Before the change:

```
$ python -c "import compressed_tensors"
ImportError: cannot import name '_round_to_fp4' from 'compressed_tensors.quantization.utils.fp4_utils'
```

After the change the same command exits 0.

## Test

Added `test_import_and_quantize_without_triton` to `tests/test_quantization/lifecycle/test_forward.py`. It masks `triton` with a meta path finder inside a subprocess, so it still exercises the no-Triton path on CI where Triton is installed, then asserts that the package imports and that the pure torch quantize path still returns output.

```
$ pytest tests/test_quantization/lifecycle/test_forward.py::test_import_and_quantize_without_triton -q
1 passed, 14 warnings in 62.78s
```

With the source fix reverted and the test kept, collection fails at the same ImportError, so the test does guard against the regression coming back.

`black` and `flake8` are both clean on the two changed files.
