### PR TITLE
Disable triton kernels

### DIFF
--- a/src/compressed_tensors/compressors/nvfp4/helpers.py
+++ b/src/compressed_tensors/compressors/nvfp4/helpers.py
@@ -87,7 +87,7 @@ def _pack_fp4_kernel(
     tl.store(packed_ptr + offsets, packed, mask=mask)
 
 
-@ImplBackend.register("pack_fp4_to_uint8", triton_req, 0)
+@ImplBackend.register("pack_fp4_to_uint8", triton_req, "disable")
 def pack_fp4_to_uint8_triton(x: torch.Tensor) -> torch.Tensor:
     m, n = x.shape
 

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -401,7 +401,7 @@ def _quantize_triton_req(
 
 
 @torch.no_grad()
-@ImplBackend.register("_quantize", _quantize_triton_req, 0)
+@ImplBackend.register("_quantize", _quantize_triton_req, "disable")
 def _quantize_triton(
     x: torch.Tensor,
     scale: torch.Tensor,

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -54,7 +54,7 @@ def _cast_to_fp4_kernel(
     tl.store(output_ptr + offsets, result, mask=mask)
 
 
-@ImplBackend.register("cast_to_fp4", triton_req, 0)
+@ImplBackend.register("cast_to_fp4", triton_req, "disable")
 def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
     """
     Triton implementation for FP4 E2M1 quantization

--- a/src/compressed_tensors/utils/impl_backend.py
+++ b/src/compressed_tensors/utils/impl_backend.py
@@ -48,7 +48,9 @@ class ImplBackend:
     _fn_registry: dict[str, Callable] = {}  # fn.__name__ -> backend_fn
 
     @classmethod
-    def register(cls, name: str, req: Callable[..., bool], priority: int):
+    def register(
+        cls, name: str, req: Callable[..., bool], priority: int | str
+    ):
         """
         Decorator that registers a backend implementation.
 
@@ -59,11 +61,17 @@ class ImplBackend:
         :param req: callable returning True when this backend is usable; receives
             the same positional and keyword arguments as the dispatch wrapper, so
             requirements can inspect actual inputs (e.g. `lambda x: x.is_cuda`)
-        :param priority: lower values are tried first (higher priority)
+        :param priority: lower values are tried first (higher priority).
+            Set to ``"disable"`` to register the function in the registry
+            (so it can still be called directly via :meth:`call`) without
+            adding it as a dispatch candidate.
         """
 
         def decorator(backend_fn: Callable) -> Callable:
             cls._add_to_registery(backend_fn)
+
+            if priority == "disable":
+                return backend_fn
 
             if name not in cls._backends:
                 cls._backends[name] = []

--- a/src/compressed_tensors/utils/impl_backend.py
+++ b/src/compressed_tensors/utils/impl_backend.py
@@ -60,16 +60,15 @@ class ImplBackend:
             the same positional and keyword arguments as the dispatch wrapper, so
             requirements can inspect actual inputs (e.g. `lambda x: x.is_cuda`)
         :param priority: lower values are tried first (higher priority).
-            Set to ``"disable"`` to register the function in the registry
-            (so it can still be called directly via :meth:`call`) without
-            adding it as a dispatch candidate.
+            Set to ``"disable"`` to skip registration entirely, treating
+            the backend as if it were never registered.
         """
 
         def decorator(backend_fn: Callable) -> Callable:
-            cls._add_to_registery(backend_fn)
-
             if priority == "disable":
                 return backend_fn
+
+            cls._add_to_registery(backend_fn)
 
             if name not in cls._backends:
                 cls._backends[name] = []

--- a/src/compressed_tensors/utils/impl_backend.py
+++ b/src/compressed_tensors/utils/impl_backend.py
@@ -48,9 +48,7 @@ class ImplBackend:
     _fn_registry: dict[str, Callable] = {}  # fn.__name__ -> backend_fn
 
     @classmethod
-    def register(
-        cls, name: str, req: Callable[..., bool], priority: int | str
-    ):
+    def register(cls, name: str, req: Callable[..., bool], priority: int | str):
         """
         Decorator that registers a backend implementation.
 

--- a/tests/test_compressors/test_fp4_quant.py
+++ b/tests/test_compressors/test_fp4_quant.py
@@ -94,6 +94,7 @@ _FP4_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
     ],
 )
 def test_pack_fp4_to_uint8_backends_match(x):
+    pytest.skip("triton kernels are disabled")
     torch_out = pack_fp4_to_uint8(x.cpu())  # CPU → torch fallback
     triton_out = ImplBackend.call(
         "pack_fp4_to_uint8_triton", x.to(torch.bfloat16).cuda()

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -1118,6 +1118,7 @@ def test_quantize_triton_matches_cpu_block_4d(
     ],
 )
 def test_quantize_backends_match(args, x, scale, zero_point, global_scale):
+    pytest.skip("triton kernels are disabled")
     is_fp8 = args.type == QuantizationType.FLOAT and args.num_bits == 8
     if is_fp8 and not _is_fp8_supported(torch.device("cuda")):
         pytest.skip("FP8 Triton kernel requires SM90+ (Hopper)")

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -767,6 +767,7 @@ def test_quantize_triton_matches_cpu(
     num_bits, type, symmetric, global_scale, group_size
 ):
     """Verify that the accelerator quantization path matches the CPU path."""
+    pytest.skip("triton kernels are disabled")
 
     num_rows = 512
     num_cols = 1024
@@ -875,6 +876,7 @@ def test_quantize_triton_matches_cpu_non_contiguous(
     num_bits, type, symmetric, global_scale, group_size
 ):
     """Verify that the accelerator path matches CPU on non-contiguous tensors."""
+    pytest.skip("triton kernels are disabled")
 
     num_rows = 512
     num_cols = 1024
@@ -983,6 +985,7 @@ def test_quantize_triton_matches_cpu_block_4d(
     """Verify that the Triton kernel (CUDA) produces identical output
     to the non-Triton (CPU) codepath for _quantize with 4D block quantization.
     """
+    pytest.skip("triton kernels are disabled")
     num_bits = 8
     type_ = "float"
     symmetric = True

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -11,6 +11,7 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
+    pytest.skip("triton kernels are disabled")
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()
@@ -25,6 +26,7 @@ def test_cast_to_fp4_cpu_gpu_match(size, dtype):
 
 @requires_gpu
 def test_cast_to_fp4_boundary_values():
+    pytest.skip("triton kernels are disabled")
     input_values = torch.tensor(
         [
             # Exact FP4 values
@@ -148,6 +150,7 @@ def test_cast_to_fp4_memory_usage(size):
     The implementation should not create excessive intermediate tensors.
     Expected memory usage should be roughly: input + output + small overhead.
     """
+    pytest.skip("triton kernels are disabled")
     torch.accelerator.empty_cache()
     torch.accelerator.reset_peak_memory_stats()
 
@@ -198,6 +201,7 @@ def test_cast_to_fp4_memory_usage(size):
     ],
 )
 def test_cast_to_fp4_backends_match(x):
+    pytest.skip("triton kernels are disabled")
     x = x.to(torch.accelerator.current_accelerator())
     torch_out = ImplBackend.call("cast_to_fp4", x)
     triton_out = ImplBackend.call("cast_to_fp4_triton", x)


### PR DESCRIPTION
## Summary
- Add `priority="disable"` support to `ImplBackend.register`
- Set all triton kernel registrations to `priority="disable"`
- Skip triton-specific tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)