### PR TITLE
fix: add missing per-tensor calibration in FP8 compress/decompress test

### DIFF
--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -5,6 +5,7 @@ import torch
 from compressed_tensors.utils.impl_backend import ImplBackend
 from compressed_tensors.utils.triton import tl, triton, triton_req
 
+
 __all__ = ["_round_to_fp4", "cast_to_fp4"]
 
 

--- a/tests/test_compressors/test_fp8_quant.py
+++ b/tests/test_compressors/test_fp8_quant.py
@@ -78,6 +78,7 @@ def test_quant_format(strategy, group_size, sc, zp):
 def test_compress_decompress_match(
     mock_per_group_calibration,
     mock_per_channel_calibration,
+    mock_per_tensor_calibration,
     strategy,
     group_size,
 ):
@@ -96,6 +97,10 @@ def test_compress_decompress_match(
     apply_quantization_config(model, quant_config)
     model.dummy.quantization_status = QuantizationStatus.CALIBRATION
 
+    if strategy == QuantizationStrategy.TENSOR:
+        mock_per_tensor_calibration(
+            model.dummy, base_name="weight", value=model.dummy.weight
+        )
     if strategy == QuantizationStrategy.GROUP:
         mock_per_group_calibration(
             model.dummy, base_name="weight", value=model.dummy.weight, group_size=128

--- a/tests/test_compressors/test_fp8_quant.py
+++ b/tests/test_compressors/test_fp8_quant.py
@@ -101,14 +101,16 @@ def test_compress_decompress_match(
         mock_per_tensor_calibration(
             model.dummy, base_name="weight", value=model.dummy.weight
         )
-    if strategy == QuantizationStrategy.GROUP:
+    elif strategy == QuantizationStrategy.GROUP:
         mock_per_group_calibration(
             model.dummy, base_name="weight", value=model.dummy.weight, group_size=128
         )
-    if strategy == QuantizationStrategy.CHANNEL:
+    elif strategy == QuantizationStrategy.CHANNEL:
         mock_per_channel_calibration(
             model.dummy, base_name="weight", value=model.dummy.weight
         )
+    else:
+        raise ValueError(f"Unsupported strategy: {strategy}")
 
     scheme = quant_config.config_groups["group_1"]
 


### PR DESCRIPTION
## Summary
- `test_compress_decompress_match[tensor-None]` was flaky because the `TENSOR` strategy path never ran calibration, leaving `weight_scale` initialized with `torch.empty()` (uninitialized memory)
- When this garbage value happened to be zero or NaN, dividing by it during quantization produced all-NaN outputs
- Added the existing `mock_per_tensor_calibration` fixture (already defined in `conftest.py` but unused here) to properly calibrate the scale before compress/decompress

## Test plan
- [x] `pytest tests/test_compressors/test_fp8_quant.py::test_compress_decompress_match -v` passes consistently
- [x] `make style` and `make quality` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)