### PR TITLE
Enable Triton backends for FP4 quantization

### DIFF
--- a/src/compressed_tensors/compressors/nvfp4/helpers.py
+++ b/src/compressed_tensors/compressors/nvfp4/helpers.py
@@ -87,7 +87,7 @@ def _pack_fp4_kernel(
     tl.store(packed_ptr + offsets, packed, mask=mask)
 
 
-@ImplBackend.register("pack_fp4_to_uint8", triton_req, "disable")
+@ImplBackend.register("pack_fp4_to_uint8", triton_req, 0)
 def pack_fp4_to_uint8_triton(x: torch.Tensor) -> torch.Tensor:
     m, n = x.shape
 

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -401,7 +401,7 @@ def _quantize_triton_req(
 
 
 @torch.no_grad()
-@ImplBackend.register("_quantize", _quantize_triton_req, "disable")
+@ImplBackend.register("_quantize", _quantize_triton_req, 0)
 def _quantize_triton(
     x: torch.Tensor,
     scale: torch.Tensor,

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -54,7 +54,7 @@ def _cast_to_fp4_kernel(
     tl.store(x_ptr + offsets, result, mask=mask)
 
 
-@ImplBackend.register("cast_to_fp4", triton_req, "disable")
+@ImplBackend.register("cast_to_fp4", triton_req, 0)
 def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
     """
     Triton implementation for FP4 E2M1 quantization


### PR DESCRIPTION
## Summary
- Enables Triton backends for FP4 quantization by setting priority to `0` (default/enabled) instead of `"disable"`
- Affects three backends: `cast_to_fp4`, `_quantize`, and `pack_fp4_to_uint8`

> **Note:** This PR depends on #822 (fix_fp4 kernel). Once #822 is merged, this PR should be rebased on main to get a clean diff showing only the priority changes.

## Test plan
- [ ] Verify NVFP4 lm eval accuracy matches baseline (compressed=0.669, recovery=95%)
- [ ] Verify all FP4 unit tests pass with Triton enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)