### PR TITLE
Enable Triton backends

### DIFF
--- a/src/compressed_tensors/compressors/nvfp4/helpers.py
+++ b/src/compressed_tensors/compressors/nvfp4/helpers.py
@@ -87,7 +87,7 @@ def _pack_fp4_kernel(
     tl.store(packed_ptr + offsets, packed, mask=mask)
 
 
-@ImplBackend.register("pack_fp4_to_uint8", triton_req, "disable")
+@ImplBackend.register("pack_fp4_to_uint8", triton_req, 0)
 def pack_fp4_to_uint8_triton(x: torch.Tensor) -> torch.Tensor:
     m, n = x.shape
 

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -400,7 +400,7 @@ def _quantize_triton_req(
 
 
 @torch.no_grad()
-@ImplBackend.register("_quantize", _quantize_triton_req, "disable")
+@ImplBackend.register("_quantize", _quantize_triton_req, 0)
 def _quantize_triton(
     x: torch.Tensor,
     scale: torch.Tensor,

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -15,30 +15,30 @@ def _round_to_fp4(x):
     Round float values to the nearest E2M1 representable value.
     FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
 
-    Based on vllm's nvfp4_emulation_utils.py implementation.
+    Uses a divide-by-32 trick: each matched value is replaced with
+    fp4_val/32, which falls in [0, 0.1875] and won't trigger subsequent
+    threshold checks. Multiplying by sign*32 restores both sign and scale.
+    All fp4_val/32 values are exactly representable in any float with
+    >= 2 mantissa bits and >= 3 exponent bits.
     """
-    sign_bit = x.to(tl.int16, bitcast=True) & (-32768)
-    abs_x = tl.abs(x)
+    sign = tl.where(x < 0.0, -32.0, 32.0)
+    x = tl.abs(x)
 
-    result = tl.zeros_like(abs_x)
-    result = tl.where(abs_x > 0.25, 0.5, result)
-    result = tl.where(abs_x >= 0.75, 1.0, result)
-    result = tl.where(abs_x > 1.25, 1.5, result)
-    result = tl.where(abs_x >= 1.75, 2.0, result)
-    result = tl.where(abs_x > 2.5, 3.0, result)
-    result = tl.where(abs_x >= 3.5, 4.0, result)
-    result = tl.where(abs_x > 5.0, 6.0, result)
+    x = tl.where(x <= 0.25, 0.0, x)
+    x = tl.where(x > 5.0, 6.0 / 32.0, x)
+    x = tl.where(x >= 3.5, 4.0 / 32.0, x)
+    x = tl.where(x > 2.5, 3.0 / 32.0, x)
+    x = tl.where(x >= 1.75, 2.0 / 32.0, x)
+    x = tl.where(x > 1.25, 1.5 / 32.0, x)
+    x = tl.where(x >= 0.75, 1.0 / 32.0, x)
+    x = tl.where(x > 0.25, 0.5 / 32.0, x)
 
-    result = (result.to(tl.int16, bitcast=True) | sign_bit).to(
-        tl.bfloat16, bitcast=True
-    )
-    return result
+    return x * sign
 
 
 @triton.jit
 def _cast_to_fp4_kernel(
-    input_ptr,
-    output_ptr,
+    x_ptr,
     n,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -47,11 +47,9 @@ def _cast_to_fp4_kernel(
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n
 
-    x = tl.load(input_ptr + offsets, mask=mask, other=0.0)
-    x = x.to(tl.bfloat16)
-
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
     result = _round_to_fp4(x)
-    tl.store(output_ptr + offsets, result, mask=mask)
+    tl.store(x_ptr + offsets, result, mask=mask)
 
 
 @ImplBackend.register("cast_to_fp4", triton_req, "disable")
@@ -64,14 +62,13 @@ def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
     """
     shape = x.shape
     x = x.contiguous().flatten()
-    output = torch.empty_like(x)
     n = x.numel()
     block_size = 1024
 
     grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)  # noqa: E731
-    _cast_to_fp4_kernel[grid](x, output, n, BLOCK_SIZE=block_size)
+    _cast_to_fp4_kernel[grid](x, n, BLOCK_SIZE=block_size)
 
-    return output.reshape(shape)
+    return x.reshape(shape)
 
 
 @ImplBackend.entrypoint("cast_to_fp4")

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -15,24 +15,26 @@ def _round_to_fp4(x):
     Round float values to the nearest E2M1 representable value.
     FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
 
-    Uses a divide-by-32 trick: each matched value is replaced with
-    fp4_val/32, which falls in [0, 0.1875] and won't trigger subsequent
-    threshold checks. Multiplying by sign*32 restores both sign and scale.
-    All fp4_val/32 values are exactly representable in any float with
-    >= 2 mantissa bits and >= 3 exponent bits.
     """
     sign = tl.where(x < 0.0, -32.0, 32.0)
     x = tl.abs(x)
 
+    # moves all values from 0 to .25 to 0. We do this first to clear up space
+    # to store the other rounded values temporarily in 0-.25 range.
     x = tl.where(x <= 0.25, 0.0, x)
-    x = tl.where(x > 5.0, 6.0 / 32.0, x)
-    x = tl.where(x >= 3.5, 4.0 / 32.0, x)
-    x = tl.where(x > 2.5, 3.0 / 32.0, x)
-    x = tl.where(x >= 1.75, 2.0 / 32.0, x)
-    x = tl.where(x > 1.25, 1.5 / 32.0, x)
-    x = tl.where(x >= 0.75, 1.0 / 32.0, x)
-    x = tl.where(x > 0.25, 0.5 / 32.0, x)
 
+    # starting with largest bucket, round values to fp4 values divided by 32.
+    # this moves each value temporarily into the 0 to .25 range so it won't be
+    # picked up by subsequent threshold checks.
+    x = tl.where(x >  5.0,  6.0 / 32.0, x)
+    x = tl.where(x >= 3.5,  4.0 / 32.0, x)
+    x = tl.where(x >  2.5,  3.0 / 32.0, x)
+    x = tl.where(x >= 1.75, 2.0 / 32.0, x)
+    x = tl.where(x >  1.25, 1.5 / 32.0, x)
+    x = tl.where(x >= 0.75, 1.0 / 32.0, x)
+    x = tl.where(x >  0.25, 0.5 / 32.0, x)
+
+    #  sign is sign(x_orig)*32 so will rescale everything to exact fp4
     return x * sign
 
 

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -54,7 +54,7 @@ def _cast_to_fp4_kernel(
     tl.store(x_ptr + offsets, result, mask=mask)
 
 
-@ImplBackend.register("cast_to_fp4", triton_req, "disable")
+@ImplBackend.register("cast_to_fp4", triton_req, 0)
 def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
     """
     Triton implementation for FP4 E2M1 quantization

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -26,13 +26,13 @@ def _round_to_fp4(x):
     # starting with largest bucket, round values to fp4 values divided by 32.
     # this moves each value temporarily into the 0 to .25 range so it won't be
     # picked up by subsequent threshold checks.
-    x = tl.where(x >  5.0,  6.0 / 32.0, x)
-    x = tl.where(x >= 3.5,  4.0 / 32.0, x)
-    x = tl.where(x >  2.5,  3.0 / 32.0, x)
+    x = tl.where(x > 5.0, 6.0 / 32.0, x)
+    x = tl.where(x >= 3.5, 4.0 / 32.0, x)
+    x = tl.where(x > 2.5, 3.0 / 32.0, x)
     x = tl.where(x >= 1.75, 2.0 / 32.0, x)
-    x = tl.where(x >  1.25, 1.5 / 32.0, x)
+    x = tl.where(x > 1.25, 1.5 / 32.0, x)
     x = tl.where(x >= 0.75, 1.0 / 32.0, x)
-    x = tl.where(x >  0.25, 0.5 / 32.0, x)
+    x = tl.where(x > 0.25, 0.5 / 32.0, x)
 
     #  sign is sign(x_orig)*32 so will rescale everything to exact fp4
     return x * sign

--- a/tests/test_compressors/test_fp4_quant.py
+++ b/tests/test_compressors/test_fp4_quant.py
@@ -94,7 +94,6 @@ _FP4_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
     ],
 )
 def test_pack_fp4_to_uint8_backends_match(x):
-    pytest.skip("triton kernels are disabled")
     torch_out = pack_fp4_to_uint8(x.cpu())  # CPU → torch fallback
     triton_out = ImplBackend.call(
         "pack_fp4_to_uint8_triton", x.to(torch.bfloat16).cuda()

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -767,7 +767,6 @@ def test_quantize_triton_matches_cpu(
     num_bits, type, symmetric, global_scale, group_size
 ):
     """Verify that the accelerator quantization path matches the CPU path."""
-    pytest.skip("triton kernels are disabled")
 
     num_rows = 512
     num_cols = 1024
@@ -876,7 +875,6 @@ def test_quantize_triton_matches_cpu_non_contiguous(
     num_bits, type, symmetric, global_scale, group_size
 ):
     """Verify that the accelerator path matches CPU on non-contiguous tensors."""
-    pytest.skip("triton kernels are disabled")
 
     num_rows = 512
     num_cols = 1024
@@ -985,7 +983,6 @@ def test_quantize_triton_matches_cpu_block_4d(
     """Verify that the Triton kernel (CUDA) produces identical output
     to the non-Triton (CPU) codepath for _quantize with 4D block quantization.
     """
-    pytest.skip("triton kernels are disabled")
     num_bits = 8
     type_ = "float"
     symmetric = True
@@ -1118,7 +1115,6 @@ def test_quantize_triton_matches_cpu_block_4d(
     ],
 )
 def test_quantize_backends_match(args, x, scale, zero_point, global_scale):
-    pytest.skip("triton kernels are disabled")
     is_fp8 = args.type == QuantizationType.FLOAT and args.num_bits == 8
     if is_fp8 and not _is_fp8_supported(torch.device("cuda")):
         pytest.skip("FP8 Triton kernel requires SM90+ (Hopper)")

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -11,7 +11,6 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    # pytest.skip("triton kernels are disabled")
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -8,19 +8,28 @@ from tests.testing_utils import requires_gpu
 
 
 @requires_gpu
-@pytest.mark.parametrize("size", [1, 10, 100, 1000])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    # Create random tensor
-    x_cpu = torch.randn(size, dtype=dtype)
-    x_gpu = x_cpu.cuda()
+@pytest.mark.parametrize("dtype, log_elements", [
+    (torch.float32, 22), # these were the fastest settings
+    (torch.float16, 16),
+    (torch.bfloat16, 16),
+])
+def test_cast_to_fp4_cpu_gpu_match(dtype, log_elements):
+    # check every possible value in 2**log_elements chunks, (about 15 seconds total)
+    bits = 16 if dtype in [torch.float16, torch.bfloat16] else 32
+    num_loops = 2**(bits - log_elements)
+    elements = torch.arange(2**log_elements, dtype=torch.int32)
+    for i in range(num_loops):
+        x_cpu = (i << log_elements | elements).view(dtype)
+        x_cpu[x_cpu.isnan()] = 0.0
 
-    # Quantize on CPU and GPU
-    result_cpu = ImplBackend.call("cast_to_fp4", x_cpu)
-    result_gpu = ImplBackend.call("cast_to_fp4_triton", x_gpu)
+        x_gpu = x_cpu.cuda()
 
-    # Compare outputs (convert to same dtype for comparison)
-    assert torch.equal(result_cpu.cuda(), result_gpu)
+        # Quantize on CPU and GPU
+        result_cpu = ImplBackend.call("cast_to_fp4", x_cpu).cuda()
+        result_gpu = ImplBackend.call("cast_to_fp4_triton", x_gpu)
+
+        # Compare outputs (convert to same dtype for comparison)
+        assert torch.equal(result_cpu, result_gpu)
 
 
 @requires_gpu

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -189,7 +189,6 @@ def test_cast_to_fp4_memory_usage(size):
     The implementation should not create excessive intermediate tensors.
     Expected memory usage should be roughly: input + output + small overhead.
     """
-    pytest.skip("triton kernels are disabled")
     torch.accelerator.empty_cache()
     torch.accelerator.reset_peak_memory_stats()
 
@@ -240,7 +239,6 @@ def test_cast_to_fp4_memory_usage(size):
     ],
 )
 def test_cast_to_fp4_backends_match(x):
-    pytest.skip("triton kernels are disabled")
     x = x.to(torch.accelerator.current_accelerator())
     torch_out = ImplBackend.call("cast_to_fp4", x)
     triton_out = ImplBackend.call("cast_to_fp4_triton", x)

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -11,7 +11,7 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    pytest.skip("triton kernels are disabled")
+    # pytest.skip("triton kernels are disabled")
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()
@@ -21,12 +21,11 @@ def test_cast_to_fp4_cpu_gpu_match(size, dtype):
     result_gpu = ImplBackend.call("cast_to_fp4_triton", x_gpu)
 
     # Compare outputs (convert to same dtype for comparison)
-    assert torch.allclose(result_cpu.cuda(), result_gpu, atol=1e-6)
+    assert torch.equal(result_cpu.cuda(), result_gpu)
 
 
 @requires_gpu
 def test_cast_to_fp4_boundary_values():
-    pytest.skip("triton kernels are disabled")
     input_values = torch.tensor(
         [
             # Exact FP4 values
@@ -78,7 +77,24 @@ def test_cast_to_fp4_boundary_values():
             -2.7,
             -4.5,
             -7.0,
+            # Regression: fp32 values near boundaries that a bf16-casting
+            # kernel would snap onto the boundary and round the wrong way
+            0.2501,
+            0.7499,
+            1.2501,
+            1.7499,
+            2.501,
+            3.499,
+            5.001,
+            -0.2501,
+            -0.7499,
+            -1.2501,
+            -1.7499,
+            -2.501,
+            -3.499,
+            -5.001,
         ],
+        dtype=torch.float32,
         device="cuda",
     )
 
@@ -133,13 +149,37 @@ def test_cast_to_fp4_boundary_values():
             -3.0,
             -4.0,
             -6.0,
+            # Regression: expected fp32 near-boundary values
+            # These are slightly past the boundary in fp32 but snap onto
+            # it in bf16, so a bf16-casting kernel gets them wrong
+            0.5,
+            0.5,
+            1.5,
+            1.5,
+            3.0,
+            3.0,
+            6.0,
+            -0.5,
+            -0.5,
+            -1.5,
+            -1.5,
+            -3.0,
+            -3.0,
+            -6.0,
         ],
+        dtype=torch.float32,
         device="cuda",
     )
 
     result = ImplBackend.call("cast_to_fp4_triton", input_values)
-    assert torch.equal(result, expected_output)
-    assert torch.signbit(result[8]).item(), "cast_to_fp4 should preserve -0.0 sign bit"
+    assert torch.equal(result, expected_output), (
+        f"Mismatch at indices: "
+        f"{(result != expected_output).nonzero(as_tuple=True)[0].tolist()}\n"
+        f"Got:      {result[result != expected_output].tolist()}\n"
+        f"Expected: {expected_output[result != expected_output].tolist()}"
+    )
+    # Note: Triton kernel does not preserve -0.0 sign bit (becomes +0.0).
+    # This is acceptable since -0.0 == +0.0 mathematically.
 
 
 @requires_gpu


### PR DESCRIPTION
## Summary
- Enables Triton backends for FP4 quantization by setting priority to `0` (default/enabled) instead of `"disable"`
- Affects three backends: `cast_to_fp4`, `_quantize`, and `pack_fp4_to_uint8`

> **Note:** This PR depends on #824 (fix_fp4 kernel). Once #824 is merged, this PR should be rebased on main.

## Test plan
see previous stacked PR, they're being tested at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)