### PR TITLE
Enable Triton kernel for cast_to_fp4 only

### DIFF
--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -15,24 +15,26 @@ def _round_to_fp4(x):
     Round float values to the nearest E2M1 representable value.
     FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
 
-    Uses a divide-by-32 trick: each matched value is replaced with
-    fp4_val/32, which falls in [0, 0.1875] and won't trigger subsequent
-    threshold checks. Multiplying by sign*32 restores both sign and scale.
-    All fp4_val/32 values are exactly representable in any float with
-    >= 2 mantissa bits and >= 3 exponent bits.
     """
     sign = tl.where(x < 0.0, -32.0, 32.0)
     x = tl.abs(x)
 
+    # moves all values from 0 to .25 to 0. We do this first to clear up space
+    # to store the other rounded values temporarily in 0-.25 range.
     x = tl.where(x <= 0.25, 0.0, x)
-    x = tl.where(x > 5.0, 6.0 / 32.0, x)
-    x = tl.where(x >= 3.5, 4.0 / 32.0, x)
-    x = tl.where(x > 2.5, 3.0 / 32.0, x)
-    x = tl.where(x >= 1.75, 2.0 / 32.0, x)
-    x = tl.where(x > 1.25, 1.5 / 32.0, x)
-    x = tl.where(x >= 0.75, 1.0 / 32.0, x)
-    x = tl.where(x > 0.25, 0.5 / 32.0, x)
 
+    # starting with largest bucket, round values to fp4 values divided by 32.
+    # this moves each value temporarily into the 0 to .25 range so it won't be
+    # picked up by subsequent threshold checks.
+    x = tl.where(x >  5.0,  6.0 / 32.0, x)
+    x = tl.where(x >= 3.5,  4.0 / 32.0, x)
+    x = tl.where(x >  2.5,  3.0 / 32.0, x)
+    x = tl.where(x >= 1.75, 2.0 / 32.0, x)
+    x = tl.where(x >  1.25, 1.5 / 32.0, x)
+    x = tl.where(x >= 0.75, 1.0 / 32.0, x)
+    x = tl.where(x >  0.25, 0.5 / 32.0, x)
+
+    #  sign is sign(x_orig)*32 so will rescale everything to exact fp4
     return x * sign
 
 

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -54,7 +54,7 @@ def _cast_to_fp4_kernel(
     tl.store(x_ptr + offsets, result, mask=mask)
 
 
-@ImplBackend.register("cast_to_fp4", triton_req, "disable")
+@ImplBackend.register("cast_to_fp4", triton_req, 0)
 def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
     """
     Triton implementation for FP4 E2M1 quantization

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -15,17 +15,16 @@ def _round_to_fp4(x):
     Round float values to the nearest E2M1 representable value.
     FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
 
+    Uses a divide-by-32 trick: each matched value is replaced with
+    fp4_val/32, which falls in [0, 0.1875] and won't trigger subsequent
+    threshold checks. Multiplying by sign*32 restores both sign and scale.
+    All fp4_val/32 values are exactly representable in any float with
+    >= 2 mantissa bits and >= 3 exponent bits.
     """
     sign = tl.where(x < 0.0, -32.0, 32.0)
     x = tl.abs(x)
 
-    # moves all values from 0 to .25 to 0. We do this first to clear up space
-    # to store the other rounded values temporarily in 0-.25 range.
     x = tl.where(x <= 0.25, 0.0, x)
-
-    # starting with largest bucket, round values to fp4 values divided by 32.
-    # this moves each value temporarily into the 0 to .25 range so it won't be
-    # picked up by subsequent threshold checks.
     x = tl.where(x > 5.0, 6.0 / 32.0, x)
     x = tl.where(x >= 3.5, 4.0 / 32.0, x)
     x = tl.where(x > 2.5, 3.0 / 32.0, x)
@@ -34,7 +33,6 @@ def _round_to_fp4(x):
     x = tl.where(x >= 0.75, 1.0 / 32.0, x)
     x = tl.where(x > 0.25, 0.5 / 32.0, x)
 
-    #  sign is sign(x_orig)*32 so will rescale everything to exact fp4
     return x * sign
 
 

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -26,13 +26,13 @@ def _round_to_fp4(x):
     # starting with largest bucket, round values to fp4 values divided by 32.
     # this moves each value temporarily into the 0 to .25 range so it won't be
     # picked up by subsequent threshold checks.
-    x = tl.where(x >  5.0,  6.0 / 32.0, x)
-    x = tl.where(x >= 3.5,  4.0 / 32.0, x)
-    x = tl.where(x >  2.5,  3.0 / 32.0, x)
+    x = tl.where(x > 5.0, 6.0 / 32.0, x)
+    x = tl.where(x >= 3.5, 4.0 / 32.0, x)
+    x = tl.where(x > 2.5, 3.0 / 32.0, x)
     x = tl.where(x >= 1.75, 2.0 / 32.0, x)
-    x = tl.where(x >  1.25, 1.5 / 32.0, x)
+    x = tl.where(x > 1.25, 1.5 / 32.0, x)
     x = tl.where(x >= 0.75, 1.0 / 32.0, x)
-    x = tl.where(x >  0.25, 0.5 / 32.0, x)
+    x = tl.where(x > 0.25, 0.5 / 32.0, x)
 
     #  sign is sign(x_orig)*32 so will rescale everything to exact fp4
     return x * sign

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -11,7 +11,6 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    # pytest.skip("triton kernels are disabled")
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -11,7 +11,7 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    pytest.skip("triton kernels are disabled")
+    # pytest.skip("triton kernels are disabled")
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()
@@ -26,7 +26,6 @@ def test_cast_to_fp4_cpu_gpu_match(size, dtype):
 
 @requires_gpu
 def test_cast_to_fp4_boundary_values():
-    pytest.skip("triton kernels are disabled")
     input_values = torch.tensor(
         [
             # Exact FP4 values

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -11,6 +11,7 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
+    pytest.skip("triton kernels are disabled")
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()
@@ -25,6 +26,7 @@ def test_cast_to_fp4_cpu_gpu_match(size, dtype):
 
 @requires_gpu
 def test_cast_to_fp4_boundary_values():
+    pytest.skip("triton kernels are disabled")
     input_values = torch.tensor(
         [
             # Exact FP4 values

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -8,25 +8,35 @@ from tests.testing_utils import requires_gpu
 
 
 @requires_gpu
-@pytest.mark.parametrize("size", [1, 10, 100, 1000])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    pytest.skip("triton kernels are disabled")
-    # Create random tensor
-    x_cpu = torch.randn(size, dtype=dtype)
-    x_gpu = x_cpu.cuda()
+@pytest.mark.parametrize(
+    "dtype, log_elements",
+    [
+        (torch.float32, 22),  # these were the fastest settings
+        (torch.float16, 16),
+        (torch.bfloat16, 16),
+    ],
+)
+def test_cast_to_fp4_cpu_gpu_match(dtype, log_elements):
+    # check every possible value in 2**log_elements chunks, (about 15 seconds total)
+    bits = 16 if dtype in [torch.float16, torch.bfloat16] else 32
+    num_loops = 2 ** (bits - log_elements)
+    elements = torch.arange(2**log_elements, dtype=torch.int32)
+    for i in range(num_loops):
+        x_cpu = (i << log_elements | elements).view(dtype)
+        x_cpu[x_cpu.isnan()] = 0.0
 
-    # Quantize on CPU and GPU
-    result_cpu = ImplBackend.call("cast_to_fp4", x_cpu)
-    result_gpu = ImplBackend.call("cast_to_fp4_triton", x_gpu)
+        x_gpu = x_cpu.cuda()
 
-    # Compare outputs (convert to same dtype for comparison)
-    assert torch.equal(result_cpu.cuda(), result_gpu)
+        # Quantize on CPU and GPU
+        result_cpu = ImplBackend.call("cast_to_fp4", x_cpu).cuda()
+        result_gpu = ImplBackend.call("cast_to_fp4_triton", x_gpu)
+
+        # Compare outputs (convert to same dtype for comparison)
+        assert torch.equal(result_cpu, result_gpu)
 
 
 @requires_gpu
 def test_cast_to_fp4_boundary_values():
-    pytest.skip("triton kernels are disabled")
     input_values = torch.tensor(
         [
             # Exact FP4 values

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -191,7 +191,6 @@ def test_cast_to_fp4_memory_usage(size):
     The implementation should not create excessive intermediate tensors.
     Expected memory usage should be roughly: input + output + small overhead.
     """
-    pytest.skip("triton kernels are disabled")
     torch.accelerator.empty_cache()
     torch.accelerator.reset_peak_memory_stats()
 
@@ -242,7 +241,6 @@ def test_cast_to_fp4_memory_usage(size):
     ],
 )
 def test_cast_to_fp4_backends_match(x):
-    pytest.skip("triton kernels are disabled")
     x = x.to(torch.accelerator.current_accelerator())
     torch_out = ImplBackend.call("cast_to_fp4", x)
     triton_out = ImplBackend.call("cast_to_fp4_triton", x)


### PR DESCRIPTION
## Summary
- Enables the Triton kernel for `cast_to_fp4` only (the kernel fixed in #824)
- Keeps the other two Triton backends (`_quantize` and `pack_fp4_to_uint8`) disabled
- This isolates the fixed kernel to verify it works correctly in CI before enabling all Triton backends

test plan:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/32161970791/job/95792732994#step:13:49953
(passes)

## Stack
- Base: #824 (fix_fp4 kernel fix)
- Next: #825 (enable all Triton backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)