### PR TITLE
[Converter] `MagnitudeExpertPrune`

### DIFF
--- a/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
+++ b/src/compressed_tensors/entrypoints/convert/convert_checkpoint.py
@@ -104,6 +104,8 @@ def convert_checkpoint(
 
     # Update config and safetensors index
     write_checkpoint_quantization_config(save_directory, converter)
+    if hasattr(converter, "update_model_config"):
+        converter.update_model_config(save_directory)
     update_safetensors_index(save_directory, total_size, weight_map)
 
 

--- a/src/compressed_tensors/entrypoints/convert/converters/__init__.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/__init__.py
@@ -9,3 +9,4 @@ from .ct_dequantizer import *
 from .autoawq import *
 from .modelopt_nvfp4 import *
 from .fp8block_dequantizer import *
+from .magnitude_expert_prune import *

--- a/src/compressed_tensors/entrypoints/convert/converters/magnitude_expert_prune.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/magnitude_expert_prune.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import torch
+from compressed_tensors.entrypoints.convert.converters import Converter
+from compressed_tensors.quantization import QuantizationConfig
+from compressed_tensors.utils.safetensors_load import (
+    find_config_path,
+    get_checkpoint_files,
+    get_weight_map,
+)
+from loguru import logger
+from safetensors import safe_open
+
+
+__all__ = ["MagnitudeExpertPrune"]
+
+NUM_EXPERTS_CONFIG_KEYS = ["num_experts", "num_local_experts", "moe_num_experts"]
+
+
+class MagnitudeExpertPrune(Converter):
+    """
+    Prune MoE experts based on router weight magnitude. Scores each expert ``i``
+    by ``sum(router.weight[i])`` and retains the top ``k`` experts per layer.
+
+    Supports both 2D expert weights (one tensor per expert, e.g.
+    ``model.layers.0.mlp.experts.3.gate_proj.weight``) and 3D stacked expert
+    weights (``model.layers.0.mlp.experts.gate_proj.weight`` with shape
+    ``[num_experts, out_features, in_features]``).
+
+    Pruning removes expert weight tensors (or slices stacked tensors), adjusts
+    router weights, and updates the model config's expert count.
+
+    :param router_pattern: regex matching router weight tensor names
+    :param expert_pattern: regex matching expert weight tensor names
+    :param k: number of experts to retain per layer
+    :param num_experts_config_key: config.json attribute name for expert count
+    :param retained_experts: pre-computed mapping of router_name -> retained
+        expert indices (sorted). Built by :meth:`from_pretrained`.
+    :param expert_to_router: mapping of expert tensor name -> associated router
+        tensor name. Built by :meth:`from_pretrained`.
+    :param expert_indices: for 2D experts, mapping of tensor name -> expert
+        index. Empty for 3D experts.
+    :param is_3d: whether expert weights are 3D stacked tensors
+    """
+
+    def __init__(
+        self,
+        router_pattern: str,
+        expert_pattern: str,
+        k: int,
+        num_experts_config_key: str,
+        retained_experts: dict[str, list[int]],
+        expert_to_router: dict[str, str],
+        expert_indices: dict[str, int],
+        is_3d: bool,
+    ):
+        self.router_pattern = re.compile(router_pattern)
+        self.expert_pattern = re.compile(expert_pattern)
+        self.k = k
+        self.num_experts_config_key = num_experts_config_key
+        self.retained_experts = retained_experts
+        self.expert_to_router = expert_to_router
+        self.expert_indices = expert_indices
+        self.is_3d = is_3d
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str | os.PathLike,
+        router_pattern: str,
+        expert_pattern: str,
+        k: int,
+        num_experts_config_key: str | None = None,
+    ) -> MagnitudeExpertPrune:
+        """
+        Build the converter by scanning the checkpoint for router weights,
+        scoring experts, and determining which to retain.
+
+        :param model_name_or_path: HuggingFace stub or local checkpoint path
+        :param router_pattern: regex matching router weight tensor names
+        :param expert_pattern: regex matching expert weight tensor names
+        :param k: number of experts to retain per layer
+        :param num_experts_config_key: config.json key holding the expert count.
+            If None, auto-detected from config.json.
+        """
+        router_re = re.compile(router_pattern)
+        expert_re = re.compile(expert_pattern)
+
+        model_files = get_checkpoint_files(model_name_or_path)
+        weight_map = get_weight_map(model_files)
+
+        # auto-detect num_experts_config_key from config.json
+        if num_experts_config_key is None:
+            num_experts_config_key = _detect_num_experts_config_key(model_files)
+
+        # collect router and expert tensor names
+        router_names = [n for n in weight_map if router_re.search(n)]
+        expert_names = [n for n in weight_map if expert_re.search(n)]
+
+        if not router_names:
+            raise ValueError(
+                f"No tensors matched router_pattern {router_pattern!r}"
+            )
+        if not expert_names:
+            raise ValueError(
+                f"No tensors matched expert_pattern {expert_pattern!r}"
+            )
+
+        # associate each expert tensor with a router tensor by longest common
+        # dot-separated prefix
+        expert_to_router = _build_expert_to_router_map(expert_names, router_names)
+
+        # detect 2D vs 3D and extract expert indices for 2D
+        expert_indices, is_3d = _detect_expert_layout(
+            expert_names, expert_to_router, weight_map, model_files
+        )
+
+        # load router weights and score experts
+        retained_experts = _compute_retained_experts(
+            router_names, weight_map, model_files, k
+        )
+
+        return cls(
+            router_pattern=router_pattern,
+            expert_pattern=expert_pattern,
+            k=k,
+            num_experts_config_key=num_experts_config_key,
+            retained_experts=retained_experts,
+            expert_to_router=expert_to_router,
+            expert_indices=expert_indices,
+            is_3d=is_3d,
+        )
+
+    def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        result: dict[str, torch.Tensor] = {}
+
+        for name in list(tensors):
+            tensor = tensors[name]
+
+            if self.router_pattern.search(name):
+                retained = self.retained_experts[name]
+                idx = torch.tensor(retained, dtype=torch.long)
+                result[name] = tensor[idx].contiguous()
+
+            elif self.expert_pattern.search(name):
+                router_name = self.expert_to_router[name]
+                retained = self.retained_experts[router_name]
+                retained_set = set(retained)
+
+                if self.is_3d:
+                    idx = torch.tensor(retained, dtype=torch.long)
+                    result[name] = tensor.index_select(0, idx).contiguous()
+                else:
+                    expert_idx = self.expert_indices[name]
+                    if expert_idx not in retained_set:
+                        continue
+                    new_idx = retained.index(expert_idx)
+                    new_name = _renumber_expert_name(name, expert_idx, new_idx)
+                    result[new_name] = tensor
+
+            else:
+                result[name] = tensor
+
+        return result
+
+    def validate(self, tensors: dict[str, torch.Tensor]):
+        for name in tensors:
+            if self.router_pattern.search(name):
+                if name not in self.retained_experts:
+                    raise ValueError(
+                        f"Router tensor {name} not found in pre-computed "
+                        "retained_experts mapping"
+                    )
+            elif self.expert_pattern.search(name):
+                if name not in self.expert_to_router:
+                    raise ValueError(
+                        f"Expert tensor {name} not found in pre-computed "
+                        "expert_to_router mapping"
+                    )
+
+    def create_config(self) -> QuantizationConfig | None:
+        return None
+
+    def get_dependencies(self, weight_name: str) -> set[str]:
+        return set()
+
+    def update_model_config(self, save_directory: str | os.PathLike):
+        """
+        Update the model config.json in ``save_directory`` to reflect the new
+        expert count after pruning.
+        """
+        config_path = find_config_path(save_directory)
+        if config_path is None:
+            logger.warning(
+                f"Could not find config file in {save_directory} to update "
+                f"{self.num_experts_config_key}"
+            )
+            return
+
+        with open(config_path, "r") as f:
+            config_data = json.load(f)
+
+        _set_nested_key(config_data, self.num_experts_config_key, self.k)
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f, indent=2, sort_keys=True)
+
+        logger.info(
+            f"Updated {self.num_experts_config_key} -> {self.k} in {config_path}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_num_experts_config_key(
+    model_files: dict[str, str],
+) -> str:
+    config_path = find_config_path(
+        os.path.dirname(next(iter(model_files.values())))
+    )
+    if config_path is None:
+        raise ValueError(
+            "Could not find config.json to auto-detect num_experts key. "
+            "Please specify num_experts_config_key explicitly."
+        )
+
+    with open(config_path, "r") as f:
+        config_data = json.load(f)
+
+    for key in NUM_EXPERTS_CONFIG_KEYS:
+        if key in config_data:
+            return key
+        if "text_config" in config_data and key in config_data["text_config"]:
+            return key
+
+    raise ValueError(
+        f"Could not find any of {NUM_EXPERTS_CONFIG_KEYS} in config.json. "
+        "Please specify num_experts_config_key explicitly."
+    )
+
+
+def _set_nested_key(config_data: dict, key: str, value: int):
+    if key in config_data:
+        old = config_data[key]
+        config_data[key] = value
+        logger.info(f"config.json: {key}: {old} -> {value}")
+    elif "text_config" in config_data and key in config_data["text_config"]:
+        old = config_data["text_config"][key]
+        config_data["text_config"][key] = value
+        logger.info(f"config.json text_config.{key}: {old} -> {value}")
+    else:
+        config_data[key] = value
+        logger.info(f"config.json: added {key} = {value}")
+
+
+def _common_prefix_len(a: str, b: str) -> int:
+    parts_a = a.split(".")
+    parts_b = b.split(".")
+    common = 0
+    for pa, pb in zip(parts_a, parts_b):
+        if pa == pb:
+            common += 1
+        else:
+            break
+    return common
+
+
+def _build_expert_to_router_map(
+    expert_names: list[str], router_names: list[str]
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for expert_name in expert_names:
+        best_router = None
+        best_len = -1
+        for router_name in router_names:
+            plen = _common_prefix_len(expert_name, router_name)
+            if plen > best_len:
+                best_len = plen
+                best_router = router_name
+        if best_router is None:
+            raise ValueError(
+                f"Could not associate expert tensor {expert_name} with any "
+                "router tensor"
+            )
+        mapping[expert_name] = best_router
+    return mapping
+
+
+def _detect_expert_layout(
+    expert_names: list[str],
+    expert_to_router: dict[str, str],
+    weight_map: dict[str, str],
+    model_files: dict[str, str],
+) -> tuple[dict[str, int], bool]:
+    """
+    Detect whether experts are 2D (per-expert tensors) or 3D (stacked).
+    For 2D, also extract the expert index from each tensor name.
+
+    Returns (expert_indices, is_3d).
+    """
+    sample_name = expert_names[0]
+    sample_shard = weight_map[sample_name]
+    sample_path = model_files[sample_shard]
+
+    with safe_open(sample_path, framework="pt") as f:
+        sample_shape = f.get_slice(sample_name).get_shape()
+
+    if len(sample_shape) >= 3:
+        return {}, True
+
+    # 2D: extract expert index from each tensor name
+    expert_indices: dict[str, int] = {}
+    for name in expert_names:
+        idx = _extract_expert_index(name)
+        if idx is None:
+            raise ValueError(
+                f"Expert tensor {name} appears to be 2D but could not extract "
+                "expert index from tensor name. Expected a numeric segment "
+                "following an 'expert'-containing segment (e.g. experts.3.weight)"
+            )
+        expert_indices[name] = idx
+
+    return expert_indices, False
+
+
+def _extract_expert_index(name: str) -> int | None:
+    """
+    Extract the expert index from a tensor name like
+    ``model.layers.0.mlp.experts.3.gate_proj.weight``.
+
+    Looks for a numeric dot-segment immediately following a segment that
+    contains 'expert'.
+    """
+    parts = name.split(".")
+    for i, part in enumerate(parts):
+        if "expert" in part.lower() and i + 1 < len(parts):
+            try:
+                return int(parts[i + 1])
+            except ValueError:
+                continue
+    return None
+
+
+def _renumber_expert_name(name: str, old_idx: int, new_idx: int) -> str:
+    """
+    Replace the expert index in a tensor name.
+
+    ``model.layers.0.mlp.experts.5.gate_proj.weight`` with old=5, new=2
+    becomes ``model.layers.0.mlp.experts.2.gate_proj.weight``.
+    """
+    parts = name.split(".")
+    for i, part in enumerate(parts):
+        if "expert" in part.lower() and i + 1 < len(parts):
+            try:
+                idx = int(parts[i + 1])
+                if idx == old_idx:
+                    parts[i + 1] = str(new_idx)
+                    return ".".join(parts)
+            except ValueError:
+                continue
+    return name
+
+
+def _compute_retained_experts(
+    router_names: list[str],
+    weight_map: dict[str, str],
+    model_files: dict[str, str],
+    k: int,
+) -> dict[str, list[int]]:
+    """
+    Load each router weight, score experts by row-sum, and return the top-k
+    expert indices (sorted) per router.
+    """
+    retained: dict[str, list[int]] = {}
+
+    # group router names by source file to minimize I/O
+    routers_by_file: dict[str, list[str]] = {}
+    for rname in router_names:
+        shard = weight_map[rname]
+        path = model_files[shard]
+        routers_by_file.setdefault(path, []).append(rname)
+
+    for path, names in routers_by_file.items():
+        with safe_open(path, framework="pt") as f:
+            for rname in names:
+                weight = f.get_tensor(rname)
+                scores = weight.sum(dim=-1)
+                num_experts = scores.shape[0]
+                if k > num_experts:
+                    raise ValueError(
+                        f"k={k} exceeds number of experts ({num_experts}) "
+                        f"in router {rname}"
+                    )
+                _, top_indices = torch.topk(scores, k)
+                retained[rname] = sorted(top_indices.tolist())
+                logger.info(
+                    f"{rname}: retaining experts {retained[rname]} "
+                    f"(dropped {num_experts - k})"
+                )
+
+    return retained

--- a/tests/test_entrypoints/convert/converters/test_magnitude_expert_prune.py
+++ b/tests/test_entrypoints/convert/converters/test_magnitude_expert_prune.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+
+import pytest
+import torch
+from compressed_tensors.entrypoints.convert.converters.magnitude_expert_prune import (
+    MagnitudeExpertPrune,
+    _build_expert_to_router_map,
+    _common_prefix_len,
+    _compute_retained_experts,
+    _extract_expert_index,
+    _renumber_expert_name,
+)
+from safetensors.torch import save_file
+
+
+@pytest.mark.unit
+def test_extract_expert_index():
+    assert _extract_expert_index("model.layers.0.mlp.experts.3.gate_proj.weight") == 3
+    assert _extract_expert_index("model.layers.0.mlp.experts.0.up_proj.weight") == 0
+    assert (
+        _extract_expert_index("model.layers.0.block_sparse_moe.experts.7.w1.weight")
+        == 7
+    )
+    assert _extract_expert_index("model.layers.0.mlp.gate.weight") is None
+
+
+@pytest.mark.unit
+def test_renumber_expert_name():
+    name = "model.layers.0.mlp.experts.5.gate_proj.weight"
+    assert (
+        _renumber_expert_name(name, 5, 2)
+        == "model.layers.0.mlp.experts.2.gate_proj.weight"
+    )
+    assert (
+        _renumber_expert_name(name, 5, 0)
+        == "model.layers.0.mlp.experts.0.gate_proj.weight"
+    )
+
+
+@pytest.mark.unit
+def test_common_prefix_len():
+    assert _common_prefix_len("a.b.c.d", "a.b.c.e") == 3
+    assert _common_prefix_len("a.b.c", "a.b.c") == 3
+    assert _common_prefix_len("a.b", "c.d") == 0
+
+
+@pytest.mark.unit
+def test_build_expert_to_router_map():
+    expert_names = [
+        "model.layers.0.mlp.experts.0.weight",
+        "model.layers.0.mlp.experts.1.weight",
+        "model.layers.1.mlp.experts.0.weight",
+    ]
+    router_names = [
+        "model.layers.0.mlp.gate.weight",
+        "model.layers.1.mlp.gate.weight",
+    ]
+    mapping = _build_expert_to_router_map(expert_names, router_names)
+    assert mapping["model.layers.0.mlp.experts.0.weight"] == (
+        "model.layers.0.mlp.gate.weight"
+    )
+    assert mapping["model.layers.0.mlp.experts.1.weight"] == (
+        "model.layers.0.mlp.gate.weight"
+    )
+    assert mapping["model.layers.1.mlp.experts.0.weight"] == (
+        "model.layers.1.mlp.gate.weight"
+    )
+
+
+@pytest.fixture
+def mock_2d_checkpoint(tmp_path):
+    """Create a mock 2D MoE checkpoint with 4 experts, 1 layer."""
+    num_experts = 4
+    hidden = 8
+    expert_dim = 16
+
+    router_weight = torch.zeros(num_experts, hidden)
+    router_weight[0] = torch.ones(hidden) * 10.0
+    router_weight[1] = torch.ones(hidden) * 1.0
+    router_weight[2] = torch.ones(hidden) * 5.0
+    router_weight[3] = torch.ones(hidden) * 8.0
+
+    tensors = {"model.layers.0.mlp.gate.weight": router_weight}
+    for i in range(num_experts):
+        tensors[f"model.layers.0.mlp.experts.{i}.gate_proj.weight"] = torch.randn(
+            expert_dim, hidden
+        )
+        tensors[f"model.layers.0.mlp.experts.{i}.up_proj.weight"] = torch.randn(
+            expert_dim, hidden
+        )
+
+    tensors["model.embed_tokens.weight"] = torch.randn(100, hidden)
+
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+
+    config = {"num_local_experts": num_experts, "model_type": "test"}
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(config, f)
+
+    return tmp_path
+
+
+@pytest.fixture
+def mock_3d_checkpoint(tmp_path):
+    """Create a mock 3D MoE checkpoint with stacked expert weights."""
+    num_experts = 4
+    hidden = 8
+    expert_dim = 16
+
+    router_weight = torch.zeros(num_experts, hidden)
+    router_weight[0] = torch.ones(hidden) * 10.0
+    router_weight[1] = torch.ones(hidden) * 1.0
+    router_weight[2] = torch.ones(hidden) * 5.0
+    router_weight[3] = torch.ones(hidden) * 8.0
+
+    tensors = {
+        "model.layers.0.mlp.gate.weight": router_weight,
+        "model.layers.0.mlp.experts.gate_proj.weight": torch.randn(
+            num_experts, expert_dim, hidden
+        ),
+        "model.layers.0.mlp.experts.up_proj.weight": torch.randn(
+            num_experts, expert_dim, hidden
+        ),
+        "model.embed_tokens.weight": torch.randn(100, hidden),
+    }
+
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+
+    config = {"num_local_experts": num_experts, "model_type": "test"}
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(config, f)
+
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_from_pretrained_2d(mock_2d_checkpoint):
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(mock_2d_checkpoint),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\d+\.",
+        k=2,
+    )
+
+    assert converter.k == 2
+    assert not converter.is_3d
+    assert converter.num_experts_config_key == "num_local_experts"
+
+    # scores: expert 0 = 80, expert 3 = 64, expert 2 = 40, expert 1 = 8
+    # top-2 should be [0, 3]
+    retained = converter.retained_experts["model.layers.0.mlp.gate.weight"]
+    assert retained == [0, 3]
+
+
+@pytest.mark.unit
+def test_process_2d(mock_2d_checkpoint):
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(mock_2d_checkpoint),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\d+\.",
+        k=2,
+    )
+
+    from safetensors import safe_open
+
+    with safe_open(str(mock_2d_checkpoint / "model.safetensors"), framework="pt") as f:
+        tensors = {name: f.get_tensor(name) for name in f.keys()}
+
+    original_expert_0_gate = tensors[
+        "model.layers.0.mlp.experts.0.gate_proj.weight"
+    ].clone()
+    original_expert_3_gate = tensors[
+        "model.layers.0.mlp.experts.3.gate_proj.weight"
+    ].clone()
+
+    result = converter.process(tensors)
+
+    # should have: gate weight (2 rows), 2 experts x 2 params, embed_tokens
+    assert "model.layers.0.mlp.gate.weight" in result
+    assert result["model.layers.0.mlp.gate.weight"].shape[0] == 2
+
+    # expert 0 stays as 0, expert 3 becomes 1
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" in result
+    assert "model.layers.0.mlp.experts.1.gate_proj.weight" in result
+    assert "model.layers.0.mlp.experts.2.gate_proj.weight" not in result
+    assert "model.layers.0.mlp.experts.3.gate_proj.weight" not in result
+
+    assert torch.equal(
+        result["model.layers.0.mlp.experts.0.gate_proj.weight"], original_expert_0_gate
+    )
+    assert torch.equal(
+        result["model.layers.0.mlp.experts.1.gate_proj.weight"], original_expert_3_gate
+    )
+
+    # non-expert tensors pass through
+    assert "model.embed_tokens.weight" in result
+
+
+@pytest.mark.unit
+def test_process_3d(mock_3d_checkpoint):
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(mock_3d_checkpoint),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\w+\.weight$",
+        k=2,
+    )
+
+    assert converter.is_3d
+
+    from safetensors import safe_open
+
+    with safe_open(str(mock_3d_checkpoint / "model.safetensors"), framework="pt") as f:
+        tensors = {name: f.get_tensor(name) for name in f.keys()}
+
+    original_gate_proj = tensors[
+        "model.layers.0.mlp.experts.gate_proj.weight"
+    ].clone()
+
+    result = converter.process(tensors)
+
+    # 3D expert tensors should be sliced to k=2 on dim 0
+    assert result["model.layers.0.mlp.experts.gate_proj.weight"].shape[0] == 2
+    retained = converter.retained_experts["model.layers.0.mlp.gate.weight"]
+    expected = original_gate_proj[torch.tensor(retained)]
+    assert torch.equal(
+        result["model.layers.0.mlp.experts.gate_proj.weight"], expected
+    )
+
+    # router sliced
+    assert result["model.layers.0.mlp.gate.weight"].shape[0] == 2
+
+
+@pytest.mark.unit
+def test_update_model_config(mock_2d_checkpoint):
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(mock_2d_checkpoint),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\d+\.",
+        k=2,
+    )
+
+    converter.update_model_config(mock_2d_checkpoint)
+
+    with open(mock_2d_checkpoint / "config.json") as f:
+        config = json.load(f)
+
+    assert config["num_local_experts"] == 2
+
+
+@pytest.mark.unit
+def test_update_model_config_text_config(tmp_path):
+    """Config with text_config wrapper (multimodal models)."""
+    num_experts = 4
+    hidden = 8
+
+    router_weight = torch.ones(num_experts, hidden)
+    tensors = {
+        "model.layers.0.mlp.gate.weight": router_weight,
+        "model.layers.0.mlp.experts.gate_proj.weight": torch.randn(
+            num_experts, 16, hidden
+        ),
+    }
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+
+    config = {
+        "model_type": "test",
+        "text_config": {"num_local_experts": num_experts},
+    }
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(config, f)
+
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(tmp_path),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\w+\.weight$",
+        k=2,
+    )
+    converter.update_model_config(tmp_path)
+
+    with open(tmp_path / "config.json") as f:
+        config = json.load(f)
+    assert config["text_config"]["num_local_experts"] == 2
+
+
+@pytest.mark.unit
+def test_validate_passes(mock_2d_checkpoint):
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(mock_2d_checkpoint),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\d+\.",
+        k=2,
+    )
+
+    from safetensors import safe_open
+
+    with safe_open(str(mock_2d_checkpoint / "model.safetensors"), framework="pt") as f:
+        tensors = {name: f.get_tensor(name) for name in f.keys()}
+
+    converter.validate(tensors)
+
+
+@pytest.mark.unit
+def test_validate_fails_unknown_router(mock_2d_checkpoint):
+    converter = MagnitudeExpertPrune.from_pretrained(
+        model_name_or_path=str(mock_2d_checkpoint),
+        router_pattern=r"\.gate\.weight$",
+        expert_pattern=r"\.experts\.\d+\.",
+        k=2,
+    )
+
+    tensors = {"model.layers.99.mlp.gate.weight": torch.randn(4, 8)}
+    with pytest.raises(ValueError, match="not found in pre-computed"):
+        converter.validate(tensors)


### PR DESCRIPTION
## Summary
- Add `MagnitudeExpertPrune` converter that prunes MoE experts based on router weight magnitude
- Each expert `i` is scored by `sum(router.weight[i])` and the top `k` experts are retained per layer
- Supports both 2D (per-expert tensors) and 3D (stacked expert tensors) checkpoint layouts
- Automatically adjusts router weights, removes pruned expert weights, re-indexes retained experts, and updates `config.json` with the new expert count
- Extends `convert_checkpoint` to call `update_model_config` on converters that implement it

## Test plan
- [x] Unit tests for helper functions (`_extract_expert_index`, `_renumber_expert_name`, `_common_prefix_len`, `_build_expert_to_router_map`)
- [x] End-to-end `from_pretrained` test with mock 2D checkpoint (verifies scoring and expert selection)
- [x] `process()` test for 2D experts (verifies tensor filtering, re-indexing, and router slicing)
- [x] `process()` test for 3D experts (verifies `index_select` on stacked tensors)
- [x] `update_model_config` test for top-level and `text_config`-wrapped configs
- [x] `validate()` tests for pass and failure cases
- [x] Verified `from_pretrained` against real `inference-optimization/Qwen3.8-1.0B-A0.6B` checkpoint (16 experts, 3D layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)