### PR TITLE
[Tests] [Bugfix] Skip frozen model loading tests to workaround transformers bug

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -52,7 +52,7 @@ class ModelCompressor:
                 - apply_quantization_config(model, ct_config.quantization_config)
                 - compressor.compress_model(model)
             - CompressedTensorsHfQuantizer._process_model_after_weight_loading
-                - if run_compressed == False: compressor.decompress_model(model)
+                - if dequantize == True: compressor.decompress_model(model)
     """
 
     # these attributes are used by `CompressedTensorsHfQuantizer` to apply configs
@@ -89,7 +89,6 @@ class ModelCompressor:
     def from_pretrained_model(
         cls,
         model: torch.nn.Module,
-        sparsity_config_or_format: Optional[object] = None,
         quantization_format: Optional[str] = None,
     ):
         """
@@ -104,9 +103,6 @@ class ModelCompressor:
             that should be applied to the entire model, overrides inferred formats
             for all quantized modules
         """
-        if sparsity_config_or_format is not None:
-            logger.warning("Passing sparsity config or format is no longer supported")
-
         # reconstruct qconfig from qschemes that are attached to the model
         quantization_config = QuantizationConfig.from_pretrained(model)
         transform_config = getattr(model, TRANSFORM_CONFIG_NAME, None)

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -24,7 +24,6 @@ from compressed_tensors.offload import is_distributed
 from compressed_tensors.quantization import QuantizationConfig, QuantizationStatus
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
 from compressed_tensors.transform import TransformConfig
-from loguru import logger
 from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -4,7 +4,6 @@
 import warnings
 from collections import defaultdict
 from enum import Enum
-from typing import Annotated, Any
 
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -161,9 +161,6 @@ class QuantizationConfig(BaseModel):
     quantization_status: QuantizationStatus = QuantizationStatus.INITIALIZED
     global_compression_ratio: float | None = None
     ignore: list[str] | None = Field(default_factory=list)
-    # `run_compressed` is a dummy, unused arg for backwards compatibility
-    # see: https://github.com/huggingface/transformers/pull/39324
-    run_compressed: Annotated[Any, Field(exclude=True)] = None
 
     def model_post_init(self, __context):
         """

--- a/tests/test_compressors/model_compressors/test_transformers_integration.py
+++ b/tests/test_compressors/model_compressors/test_transformers_integration.py
@@ -63,8 +63,6 @@ def test_compress_model(frozen_stub, compressed_stub):
     ],
 )
 def test_decompress_model(model_stub, compressed_stub):
-    from transformers.utils.quantization_config import CompressedTensorsConfig
-
     model = AutoModelForCausalLM.from_pretrained(model_stub, torch_dtype=torch.float32)
     compressor = ModelCompressor.from_pretrained_model(model)
     true_decompressed_model = AutoModelForCausalLM.from_pretrained(

--- a/tests/test_compressors/model_compressors/test_transformers_integration.py
+++ b/tests/test_compressors/model_compressors/test_transformers_integration.py
@@ -10,29 +10,29 @@ from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
 )
 from compressed_tensors.quantization.quant_args import FP8_E4M3_DATA
-from tests.testing_utils import requires_gpu
+from tests.testing_utils import requires_gpu, requires_version
 from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.utils.quantization_config import CompressedTensorsConfig
 
 
+@requires_version("transformers", "!=5.15.0")
 @pytest.mark.parametrize(
-    "frozen_stub,q_format,compressed_stub",
+    "frozen_stub,compressed_stub",
     [
         (
             "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-uncompressed",
-            "float-quantized",
             "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-compressed",
         ),
         (
             "nm-testing/llama2.c-stories15M-ultrachat-mixed-uncompressed",
-            "pack-quantized",
             "nm-testing/llama2.c-stories15M-ultrachat-mixed-compressed",
         ),
     ],
 )
-def test_compress_model(frozen_stub, q_format, compressed_stub):
+def test_compress_model(frozen_stub, compressed_stub):
     """Check that compression generates the expected compressed model"""
     model = AutoModelForCausalLM.from_pretrained(frozen_stub, torch_dtype=torch.float32)
-    compressor = ModelCompressor.from_pretrained_model(model, None, q_format)
+    compressor = ModelCompressor.from_pretrained_model(model)
     true_compressed_model = AutoModelForCausalLM.from_pretrained(
         compressed_stub, torch_dtype=torch.float32
     )
@@ -47,30 +47,29 @@ def test_compress_model(frozen_stub, q_format, compressed_stub):
         assert torch.equal(compressed[key], true_compressed[key])
 
 
+@requires_version("transformers", "!=5.15.0")
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize(
-    "model_stub,q_format,compressed_stub",
+    "model_stub,compressed_stub",
     [
         (
             "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-uncompressed",
-            "float-quantized",
             "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-compressed",
         ),
         (
             "nm-testing/llama2.c-stories15M-ultrachat-mixed-uncompressed",
-            "pack-quantized",
             "nm-testing/llama2.c-stories15M-ultrachat-mixed-compressed",
         ),
     ],
 )
-def test_decompress_model(model_stub, q_format, compressed_stub):
+def test_decompress_model(model_stub, compressed_stub):
     from transformers.utils.quantization_config import CompressedTensorsConfig
 
     model = AutoModelForCausalLM.from_pretrained(model_stub, torch_dtype=torch.float32)
-    compressor = ModelCompressor.from_pretrained_model(model, None, q_format)
+    compressor = ModelCompressor.from_pretrained_model(model)
     true_decompressed_model = AutoModelForCausalLM.from_pretrained(
         compressed_stub,
-        quantization_config=CompressedTensorsConfig(run_compressed=False),
+        quantization_config=CompressedTensorsConfig(dequantize=True),
         torch_dtype=torch.float32,
     )
 
@@ -125,7 +124,7 @@ def test_multiple_quant_compressors():
     initialize_module_for_quantization(model[1])
     model[1].quantization_status = "frozen"
 
-    compressor = ModelCompressor.from_pretrained_model(model, None)
+    compressor = ModelCompressor.from_pretrained_model(model)
     compressor.compress_model(model)
     assert compressor.quantization_config.format == CompressionFormat.mixed_precision
     assert model[0].quantization_scheme.format == scheme_fp8.format

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -111,6 +111,50 @@ def is_gpu_available():
         return False
 
 
+def requires_version(package_name: str, req_version: str) -> pytest.MarkDecorator:
+    """
+    Pytest decorator to skip if the installed package version doesn't satisfy
+    a version requirement. Supports operator prefixes: >, >=, <, <=, ==, !=.
+    A bare version (no operator) is treated as >=.
+
+    Usage:
+    @requires_version("transformers", ">=4.45.0")
+    @requires_version("transformers", ">5.15")
+    @requires_version("transformers", "<6.0")
+    """
+    import operator
+    import re
+    from importlib.metadata import PackageNotFoundError, version
+
+    from packaging.version import Version
+
+    ops = {
+        ">=": operator.ge,
+        ">": operator.gt,
+        "<=": operator.le,
+        "<": operator.lt,
+        "==": operator.eq,
+        "!=": operator.ne,
+    }
+
+    match = re.match(r"^(>=|<=|!=|>|<|==)?(.+)$", req_version)
+    op_str = match.group(1) or ">="
+    ver_str = match.group(2)
+    compare = ops[op_str]
+
+    try:
+        installed = version(package_name)
+    except PackageNotFoundError:
+        return pytest.mark.skip(
+            reason=f"{package_name} is not installed",
+        )
+
+    return pytest.mark.skipif(
+        not compare(Version(installed), Version(ver_str)),
+        reason=(f"{package_name} {op_str}{ver_str} required, " f"found {installed}"),
+    )
+
+
 def requires_gpu(test_case_or_num):
     """
     Pytest decorator to skip based on number of available GPUs.


### PR DESCRIPTION
## Purpose ##
* Fix test failures as a result of transformers==5.15.0
  * Changes made [here](https://github.com/huggingface/transformers/pull/47152#issuecomment-5298046247) result in frozen checkpoints not loading properly
  * Since frozen checkpoints are very rarely uploaded or downloaded outside of testing, this is not a serious error
* Miscellaneous cleanup and removal of deprecated code

## Changes ##
* Remove `ModelCompressor.from_pretrained_model`'s  sparsity argument (has since been removed in vllm)
* Remove `q_format` argument from test parameterization (not necessary since qformat is autoinferred). The test is now more reflective of real use of `ModelCompressor`
* Skip failing tests which use frozen checkpoints until next release

## Testing ##
* Tests pass after local patch to transformers (will upstream)
* Tests now correctly skips