### PR TITLE
Restore converter validate methods and fix pack-quantized decompress on meta

### DIFF
--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -156,7 +156,7 @@ class PackedQuantizationCompressor(BaseCompressor):
                     f"Cannot recover exact weight shape on meta for "
                     f"{weights.strategy} pack-quantized weights; using an upper "
                     "bound within 32/num_bits of the true in_features. This "
-                    "affects meta validation only."
+                    "affect validation only."
                 )
                 in_features = packed.shape[-1] * 32 // weights.num_bits
             state_dict["weight"] = torch.empty(

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -13,6 +13,7 @@ from compressed_tensors.compressors.pack_quantized.helpers import (
     unpack_from_int32,
 )
 from compressed_tensors.config import CompressionFormat
+from compressed_tensors.logger import logger
 from compressed_tensors.quantization import (
     ActivationOrdering,
     QuantizationScheme,
@@ -136,8 +137,30 @@ class PackedQuantizationCompressor(BaseCompressor):
         weights = scheme.weights
 
         if packed.device.type == "meta":
+            # Build the dequantized weight shape locally instead of reading
+            # weight_shape, which arrives on meta (no data) in the validate
+            # pass. The validate pass discards this tensor, so an inexact
+            # in_features does not affect correctness.
+            if weights.strategy in (
+                QuantizationStrategy.GROUP.value,
+                QuantizationStrategy.TENSOR_GROUP.value,
+            ):
+                # exact: the scale pins down in_features for grouped strategies
+                in_features = scale.shape[-1] * weights.group_size
+            else:
+                # channel/tensor packing does not preserve exact in_features:
+                # the packed width only pins it to within 32/num_bits values,
+                # so this is the ceil-consistent upper bound. weight_shape
+                # holds the exact value but arrives on meta with no data.
+                logger.bind(log_once=True).warning(
+                    f"Cannot recover exact weight shape on meta for "
+                    f"{weights.strategy} pack-quantized weights; using an upper "
+                    "bound within 32/num_bits of the true in_features. This "
+                    "affects meta validation only."
+                )
+                in_features = packed.shape[-1] * 32 // weights.num_bits
             state_dict["weight"] = torch.empty(
-                tuple(original_shape.tolist()),
+                (*packed.shape[:-1], in_features),
                 dtype=scale.dtype,
                 device="meta",
             )

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -156,7 +156,7 @@ class PackedQuantizationCompressor(BaseCompressor):
                     f"Cannot recover exact weight shape on meta for "
                     f"{weights.strategy} pack-quantized weights; using an upper "
                     "bound within 32/num_bits of the true in_features. This "
-                    "affect validation only."
+                    "affects validation only."
                 )
                 in_features = packed.shape[-1] * 32 // weights.num_bits
             state_dict["weight"] = torch.empty(

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -60,6 +60,48 @@ class CompressedTensorsDequantizer(Converter):
                 infer_module_format(torch.nn.Linear, scheme)
             )
 
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Validate that every targeted module carries exactly its expected
+        compression params, and that no matched module has stray tensors,
+        raising a descriptive ValueError otherwise. Returns the dequantized
+        tensors so chained converters observe the resulting (uncompressed)
+        format.
+        """
+        consumed_keys = set()
+        matched_modules = set()
+        for scheme in self.quant_config.config_groups.values():
+            compressor = BaseCompressor.get_value_from_registry(scheme.format)
+            param_names = compressor.compression_param_names(scheme)
+            for module_name, _ in match_quantizable_tensors(
+                tensors,
+                ignore=self.quant_config.ignore,
+                targets=scheme.targets,
+                param_targets=[param_names[0]],
+            ):
+                matched_modules.add(module_name)
+                for param_name in param_names:
+                    expected_key = f"{module_name}.{param_name}"
+                    if expected_key not in tensors:
+                        raise ValueError(
+                            f"Expected compression param {expected_key} not found "
+                            f"for targeted module {module_name}"
+                        )
+                    consumed_keys.add(expected_key)
+
+        unconsumed_tensor_names = [
+            name
+            for name in tensors
+            if name not in consumed_keys and name.rpartition(".")[0] in matched_modules
+        ]
+        if unconsumed_tensor_names:
+            raise ValueError(
+                f"Found {len(unconsumed_tensor_names)} unconsumed tensor(s) within "
+                f"matched modules -- {unconsumed_tensor_names}"
+            )
+
+        return self.process(tensors)
+
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Dequantize compressed tensors to full-precision weight tensors in dtype

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -9,7 +9,11 @@ from compressed_tensors.compressors import BaseCompressor
 from compressed_tensors.compressors.format import infer_module_format
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.entrypoints.convert.converters import Converter
-from compressed_tensors.quantization import KVCacheScaleType, QuantizationConfig
+from compressed_tensors.quantization import (
+    KVCacheScaleType,
+    QuantizationConfig,
+    QuantizationMetadata,
+)
 from compressed_tensors.utils.match import match_name, match_quantizable_tensors
 from compressed_tensors.utils.safetensors_load import (
     get_checkpoint_files,
@@ -62,45 +66,35 @@ class CompressedTensorsDequantizer(Converter):
 
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
-        Validate that every targeted module carries exactly its expected
-        compression params, and that no matched module has stray tensors,
-        raising a descriptive ValueError otherwise. Returns the dequantized
-        tensors so chained converters observe the resulting (uncompressed)
-        format.
+        Dequantize, then assert the result carries no leftover quantization
+        params on non-ignored modules. A residual qparam means the configured
+        targets missed a module that still holds compressed weights. Missing
+        params surface as a KeyError from process and are re-raised as a
+        ValueError so CI catches them. Returns the dequantized tensors so
+        chained converters observe the resulting (uncompressed) format.
         """
-        consumed_keys = set()
-        matched_modules = set()
-        for scheme in self.quant_config.config_groups.values():
-            compressor = BaseCompressor.get_value_from_registry(scheme.format)
-            param_names = compressor.compression_param_names(scheme)
-            for module_name, _ in match_quantizable_tensors(
-                tensors,
-                ignore=self.quant_config.ignore,
-                targets=scheme.targets,
-                param_targets=[param_names[0]],
-            ):
-                matched_modules.add(module_name)
-                for param_name in param_names:
-                    expected_key = f"{module_name}.{param_name}"
-                    if expected_key not in tensors:
-                        raise ValueError(
-                            f"Expected compression param {expected_key} not found "
-                            f"for targeted module {module_name}"
-                        )
-                    consumed_keys.add(expected_key)
+        try:
+            tensors = self.process(tensors)
+        except KeyError as e:
+            raise ValueError(f"Missing expected compression param {e}") from e
 
-        unconsumed_tensor_names = [
+        qparam_names = set(QuantizationMetadata.all_qparam_names())
+        residual = [
             name
             for name in tensors
-            if name not in consumed_keys and name.rpartition(".")[0] in matched_modules
+            if name.rpartition(".")[-1] in qparam_names
+            and not any(
+                match_name(name.rpartition(".")[0], ignore)
+                for ignore in self.quant_config.ignore
+            )
         ]
-        if unconsumed_tensor_names:
+        if residual:
             raise ValueError(
-                f"Found {len(unconsumed_tensor_names)} unconsumed tensor(s) within "
-                f"matched modules -- {unconsumed_tensor_names}"
+                f"Found {len(residual)} residual quantization param(s) after "
+                f"dequantization, indicating untargeted or orphan qparams: {residual}"
             )
 
-        return self.process(tensors)
+        return tensors
 
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """

--- a/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
@@ -34,47 +34,31 @@ class FP8BlockDequantizer(Converter):
 
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
-        Ensure every targeted weight has its matching weight_scale_inv (and vice
-        versa), and no untargeted module carries a stray weight_scale_inv, raising
-        ValueError otherwise. Returns the processed tensors so chained converters
-        observe the resulting format.
+        Dequantize, then assert no leftover weight_scale_inv remains on a
+        non-ignored module. A residual weight_scale_inv means the configured
+        targets missed a block-quantized weight. A targeted weight missing its
+        weight_scale_inv surfaces as a KeyError from process and is re-raised as
+        a ValueError so CI catches it. Returns the processed tensors so chained
+        converters observe the resulting format.
         """
-        targeted_names = [
+        try:
+            tensors = self.process(tensors)
+        except KeyError as e:
+            raise ValueError(f"Missing expected weight_scale_inv {e}") from e
+
+        residual = [
             name
-            for _, name in match_quantizable_tensors(
-                tensors, self.ignore, self.targets, param_targets=self.param_names
+            for name in tensors
+            if name.rpartition(".")[-1] == "weight_scale_inv"
+            and not any(match_name(name.rpartition(".")[0], ign) for ign in self.ignore)
+        ]
+        if residual:
+            raise ValueError(
+                f"Found {len(residual)} residual weight_scale_inv after "
+                f"dequantization, indicating untargeted or orphan scales: {residual}"
             )
-        ]
-        for name in targeted_names:
-            module_name, _, param_name = name.rpartition(".")
-            if (
-                param_name == "weight"
-                and f"{module_name}.weight_scale_inv" not in tensors
-            ):
-                raise ValueError(
-                    f"Found weight without corresponding weight_scale_inv {name}"
-                )
-            if (
-                param_name == "weight_scale_inv"
-                and f"{module_name}.weight" not in tensors
-            ):
-                raise ValueError(
-                    f"Found weight_scale_inv without corresponding weight {name}"
-                )
 
-        disallowed_names = ["weight_scale_inv"]
-        untargeted_names = [
-            name
-            for name in tensors.keys()
-            if name not in targeted_names
-            and not any(match_name(name, ign) for ign in self.ignore)
-        ]
-        for name in untargeted_names:
-            param_name = name.rpartition(".")[-1]
-            if param_name in disallowed_names:
-                raise ValueError(f"Found unexpected non-targeted tensor {name}")
-
-        return self.process(tensors)
+        return tensors
 
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """

--- a/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/fp8block_dequantizer.py
@@ -32,6 +32,50 @@ class FP8BlockDequantizer(Converter):
 
         self.param_names = ["weight", "weight_scale_inv"]
 
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Ensure every targeted weight has its matching weight_scale_inv (and vice
+        versa), and no untargeted module carries a stray weight_scale_inv, raising
+        ValueError otherwise. Returns the processed tensors so chained converters
+        observe the resulting format.
+        """
+        targeted_names = [
+            name
+            for _, name in match_quantizable_tensors(
+                tensors, self.ignore, self.targets, param_targets=self.param_names
+            )
+        ]
+        for name in targeted_names:
+            module_name, _, param_name = name.rpartition(".")
+            if (
+                param_name == "weight"
+                and f"{module_name}.weight_scale_inv" not in tensors
+            ):
+                raise ValueError(
+                    f"Found weight without corresponding weight_scale_inv {name}"
+                )
+            if (
+                param_name == "weight_scale_inv"
+                and f"{module_name}.weight" not in tensors
+            ):
+                raise ValueError(
+                    f"Found weight_scale_inv without corresponding weight {name}"
+                )
+
+        disallowed_names = ["weight_scale_inv"]
+        untargeted_names = [
+            name
+            for name in tensors.keys()
+            if name not in targeted_names
+            and not any(match_name(name, ign) for ign in self.ignore)
+        ]
+        for name in untargeted_names:
+            param_name = name.rpartition(".")[-1]
+            if param_name in disallowed_names:
+                raise ValueError(f"Found unexpected non-targeted tensor {name}")
+
+        return self.process(tensors)
+
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Dequantize the fp8 block tensors (weight, weight_scale_inv) to full-precision

--- a/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
@@ -45,29 +45,35 @@ class ModelOptNvfp4Converter(Converter):
         rather than re-deriving the target matching. Returns the processed
         tensors so chained converters observe the resulting format.
         """
-        tensors = self.process(tensors)
+        targeted_names = [
+            name
+            for _, name in match_quantizable_tensors(
+                tensors, self.ignore, self.targets, param_targets=self.param_names
+            )
+        ]
+        for name in targeted_names:
+            param_name = name.rpartition(".")[-1]
 
-        qparam_names = {
+        disallowed_names = [
             "input_scale",
             "weight_scale",
             "weight_scale_2",
             "k_scale",
             "v_scale",
-        }
-        orphans = []
-        for name in tensors:
-            module_name, _, param_name = name.rpartition(".")
-            if (
-                param_name in qparam_names
-                and f"{module_name}.weight_packed" not in tensors
-                and not any(match_name(module_name, ign) for ign in self.ignore)
-            ):
-                orphans.append(name)
-        if orphans:
-            raise ValueError(
-                f"Found {len(orphans)} quantization param(s) without a converted "
-                f"weight_packed, indicating untargeted or orphan qparams: {orphans}"
-            )
+        ]
+        untargeted_names = [
+            name
+            for name in tensors.keys()
+            if name not in targeted_names
+            and not any(match_name(name, ign) for ign in self.ignore)
+        ]
+        for name in untargeted_names:
+            param_name = name.rpartition(".")[-1]
+
+            if param_name in disallowed_names:
+                raise ValueError(f"Hit unexpected non-targeted tensor {name}")
+
+        tensors = self.process(tensors)
 
         return tensors
 

--- a/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
@@ -38,42 +38,34 @@ class ModelOptNvfp4Converter(Converter):
 
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
-        Process, then flag any non-ignored module that still carries a source
-        quantization param without a converted weight_packed. process renames
-        weight to weight_packed only on modules it handled, so weight_packed is
-        the marker of a processed module; checking for it keys off process output
-        rather than re-deriving the target matching. Returns the processed
-        tensors so chained converters observe the resulting format.
+        Process, then flag any non-ignored qparam that a full process run would
+        only leave on a converted module. process renames weight to weight_packed
+        on every module it handles, so weight_packed marks a processed module,
+        and it only retypes k/v scales when a kv_cache_scheme is configured.
+        Checking both keys off process's output rather than re-deriving the
+        target matching. Returns the processed tensors so chained converters
+        observe the resulting format.
         """
-        targeted_names = [
-            name
-            for _, name in match_quantizable_tensors(
-                tensors, self.ignore, self.targets, param_targets=self.param_names
-            )
-        ]
-        for name in targeted_names:
-            param_name = name.rpartition(".")[-1]
-
-        disallowed_names = [
-            "input_scale",
-            "weight_scale",
-            "weight_scale_2",
-            "k_scale",
-            "v_scale",
-        ]
-        untargeted_names = [
-            name
-            for name in tensors.keys()
-            if name not in targeted_names
-            and not any(match_name(name, ign) for ign in self.ignore)
-        ]
-        for name in untargeted_names:
-            param_name = name.rpartition(".")[-1]
-
-            if param_name in disallowed_names:
-                raise ValueError(f"Hit unexpected non-targeted tensor {name}")
-
         tensors = self.process(tensors)
+
+        source_qparams = {"input_scale", "weight_scale", "weight_scale_2"}
+        orphans = []
+        for name in tensors:
+            module_name, _, param_name = name.rpartition(".")
+            if any(match_name(module_name, ign) for ign in self.ignore):
+                continue
+            converted = f"{module_name}.weight_packed" in tensors
+            if param_name in source_qparams and not converted:
+                orphans.append(name)
+            elif param_name in {"k_scale", "v_scale"} and (
+                self.kv_cache_scheme is None or not converted
+            ):
+                orphans.append(name)
+        if orphans:
+            raise ValueError(
+                f"Found {len(orphans)} quantization param(s) without a converted "
+                f"weight_packed, indicating untargeted or orphan qparams: {orphans}"
+            )
 
         return tensors
 

--- a/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
@@ -38,35 +38,38 @@ class ModelOptNvfp4Converter(Converter):
 
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
-        Ensure no untargeted module carries a quantization param that should only
-        appear on targeted modules, raising ValueError otherwise. Returns the
-        processed tensors so chained converters observe the resulting format.
+        Process, then flag any non-ignored module that still carries a source
+        quantization param without a converted weight_packed. process renames
+        weight to weight_packed only on modules it handled, so weight_packed is
+        the marker of a processed module; checking for it keys off process output
+        rather than re-deriving the target matching. Returns the processed
+        tensors so chained converters observe the resulting format.
         """
-        targeted_names = [
-            name
-            for _, name in match_quantizable_tensors(
-                tensors, self.ignore, self.targets, param_targets=self.param_names
-            )
-        ]
-        disallowed_names = [
+        tensors = self.process(tensors)
+
+        qparam_names = {
             "input_scale",
             "weight_scale",
             "weight_scale_2",
             "k_scale",
             "v_scale",
-        ]
-        untargeted_names = [
-            name
-            for name in tensors.keys()
-            if name not in targeted_names
-            and not any(match_name(name, ign) for ign in self.ignore)
-        ]
-        for name in untargeted_names:
-            param_name = name.rpartition(".")[-1]
-            if param_name in disallowed_names:
-                raise ValueError(f"Hit unexpected non-targeted tensor {name}")
+        }
+        orphans = []
+        for name in tensors:
+            module_name, _, param_name = name.rpartition(".")
+            if (
+                param_name in qparam_names
+                and f"{module_name}.weight_packed" not in tensors
+                and not any(match_name(module_name, ign) for ign in self.ignore)
+            ):
+                orphans.append(name)
+        if orphans:
+            raise ValueError(
+                f"Found {len(orphans)} quantization param(s) without a converted "
+                f"weight_packed, indicating untargeted or orphan qparams: {orphans}"
+            )
 
-        return self.process(tensors)
+        return tensors
 
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """

--- a/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/modelopt_nvfp4.py
@@ -36,6 +36,38 @@ class ModelOptNvfp4Converter(Converter):
         if self.kv_cache_scheme is not None:
             self.param_names += ["k_scale", "v_scale"]
 
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Ensure no untargeted module carries a quantization param that should only
+        appear on targeted modules, raising ValueError otherwise. Returns the
+        processed tensors so chained converters observe the resulting format.
+        """
+        targeted_names = [
+            name
+            for _, name in match_quantizable_tensors(
+                tensors, self.ignore, self.targets, param_targets=self.param_names
+            )
+        ]
+        disallowed_names = [
+            "input_scale",
+            "weight_scale",
+            "weight_scale_2",
+            "k_scale",
+            "v_scale",
+        ]
+        untargeted_names = [
+            name
+            for name in tensors.keys()
+            if name not in targeted_names
+            and not any(match_name(name, ign) for ign in self.ignore)
+        ]
+        for name in untargeted_names:
+            param_name = name.rpartition(".")[-1]
+            if param_name in disallowed_names:
+                raise ValueError(f"Hit unexpected non-targeted tensor {name}")
+
+        return self.process(tensors)
+
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Map the modelopt NVFP4 tensors to the appropriate compressed-tensors

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -417,13 +417,18 @@ def test_power_of_2_bits_same_packed_output_as_old(num_bits, k):
 
 
 @pytest.mark.parametrize(
-    "strategy,group_size,scale_shape",
+    "strategy,group_size,scale_shape,in_features,expected_width",
     [
-        (QuantizationStrategy.GROUP, 128, (256, 4)),
-        (QuantizationStrategy.CHANNEL, None, (256, 1)),
+        (QuantizationStrategy.GROUP, 128, (256, 4), 512, 512),
+        (QuantizationStrategy.CHANNEL, None, (256, 1), 512, 512),
+        # non-aligned channel: 350*4 bits pack to 44 int32 cols, whose upper-bound
+        # placeholder is 44*32//4 = 352 (inexact by design on meta)
+        (QuantizationStrategy.CHANNEL, None, (256, 1), 350, 352),
     ],
 )
-def test_decompress_on_meta(strategy, group_size, scale_shape):
+def test_decompress_on_meta(
+    strategy, group_size, scale_shape, in_features, expected_width
+):
     """
     decompress must run on meta tensors: the validate_file convert path loads
     every param on device="meta", so weight_shape arrives with no data. The
@@ -431,7 +436,7 @@ def test_decompress_on_meta(strategy, group_size, scale_shape):
     read from weight_shape. Regression for the pack-quantized meta crash
     (NotImplementedError: Cannot copy out of meta tensor; no data!).
     """
-    out_features, in_features = 256, 512
+    out_features = 256
     module_sd = {
         "weight": torch.rand((out_features, in_features)),
         "weight_scale": torch.rand(scale_shape).to(torch.float32),
@@ -456,6 +461,6 @@ def test_decompress_on_meta(strategy, group_size, scale_shape):
 
     assert weight.device.type == "meta"
     assert weight.shape[0] == out_features
-    # group in_features is recovered exactly from the scale; channel is a
-    # packed-width placeholder, exact here since in_features packs with no padding
-    assert weight.shape[-1] == in_features
+    # group recovers in_features exactly from the scale; channel is a packed-width
+    # upper bound, exact only when in_features packs with no padding
+    assert weight.shape[-1] == expected_width

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -414,3 +414,48 @@ def test_power_of_2_bits_same_packed_output_as_old(num_bits, k):
     assert torch.equal(
         pack_to_int32(value, num_bits), _old_pack_to_int32(value, num_bits)
     )
+
+
+@pytest.mark.parametrize(
+    "strategy,group_size,scale_shape",
+    [
+        (QuantizationStrategy.GROUP, 128, (256, 4)),
+        (QuantizationStrategy.CHANNEL, None, (256, 1)),
+    ],
+)
+def test_decompress_on_meta(strategy, group_size, scale_shape):
+    """
+    decompress must run on meta tensors: the validate_file convert path loads
+    every param on device="meta", so weight_shape arrives with no data. The
+    original weight shape is rebuilt from the packed/scale shapes rather than
+    read from weight_shape. Regression for the pack-quantized meta crash
+    (NotImplementedError: Cannot copy out of meta tensor; no data!).
+    """
+    out_features, in_features = 256, 512
+    module_sd = {
+        "weight": torch.rand((out_features, in_features)),
+        "weight_scale": torch.rand(scale_shape).to(torch.float32),
+    }
+    scheme = QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(
+            num_bits=4,
+            strategy=strategy.value,
+            symmetric=True,
+            group_size=group_size,
+        ),
+    )
+    compressed = PackedQuantizationCompressor.compress(module_sd, scheme=scheme)
+
+    # emulate validate_file: every param, including weight_shape, loaded on meta
+    meta_sd = {k: v.to("meta") for k, v in compressed.items()}
+    assert meta_sd["weight_shape"].device.type == "meta"
+
+    decompressed = PackedQuantizationCompressor.decompress(meta_sd, scheme=scheme)
+    weight = decompressed["weight"]
+
+    assert weight.device.type == "meta"
+    assert weight.shape[0] == out_features
+    # group in_features is recovered exactly from the scale; channel is a
+    # packed-width placeholder, exact here since in_features packs with no padding
+    assert weight.shape[-1] == in_features

--- a/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
+++ b/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
@@ -127,6 +127,34 @@ def test_validate_raises_on_missing_scale():
 
 
 @pytest.mark.unit
+def test_validate_passes_with_ignored_compressed_module():
+    # An ignored module keeps its compressed qparams; the residual check must
+    # not flag them as orphans.
+    dequantizer = _create_dequantizer(ignore=["model.embed_tokens", "re:.*down_proj.*"])
+    tensors = _create_dummy_tensors(device=torch.device("meta"))
+
+    result = dequantizer.validate(tensors)
+
+    # up_proj is dequantized, down_proj is left compressed (ignored)
+    assert result["model.layers.0.mlp.up_proj.weight"].dtype == torch.bfloat16
+    assert "model.layers.0.mlp.down_proj.weight_scale" in result
+
+
+@pytest.mark.unit
+def test_validate_raises_on_untargeted_scale():
+    # A module that is neither targeted nor ignored but carries a qparam is an
+    # orphan and must raise.
+    dequantizer = _create_dequantizer(ignore=["model.embed_tokens"])
+    tensors = _create_dummy_tensors(device=torch.device("meta"))
+    tensors["model.layers.0.self_attn.q_proj.weight_scale"] = torch.rand(
+        128, 1, dtype=torch.float32, device="meta"
+    )
+
+    with pytest.raises(ValueError):
+        dequantizer.validate(tensors)
+
+
+@pytest.mark.unit
 def test_validate_returns_correct_key_count():
     dequantizer = _create_dequantizer(ignore=["model.embed_tokens"])
     tensors = _create_dummy_tensors(device=torch.device("meta"))

--- a/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
+++ b/tests/test_entrypoints/convert/converters/test_ct_dequantizer.py
@@ -122,7 +122,7 @@ def test_validate_raises_on_missing_scale():
     tensors = _create_dummy_tensors(device=torch.device("meta"))
     del tensors["model.layers.0.mlp.up_proj.weight_scale"]
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         dequantizer.validate(tensors)
 
 

--- a/tests/test_entrypoints/convert/converters/test_fp8block_dequantizer.py
+++ b/tests/test_entrypoints/convert/converters/test_fp8block_dequantizer.py
@@ -261,3 +261,51 @@ def _verify_block_conversion(
                 rtol=1e-2,
                 atol=1e-3,
             ), f"Block ({row_block}, {col_block}) conversion mismatch"
+
+
+@pytest.mark.unit
+def test_fp8_block_validate_raises_on_missing_scale_inv():
+    """
+    A targeted weight without its matching weight_scale_inv must raise ValueError.
+    Regression for validation dropped in the multi-converter refactor (#805).
+    """
+    converter = FP8BlockDequantizer(
+        targets=[r"re:.*proj$"], weight_block_size=(128, 128)
+    )
+
+    with torch.device("meta"):
+        tensors = {
+            "model.layer0.mlp.up_proj.weight": torch.empty(
+                256, 256, dtype=torch.float8_e4m3fn
+            ),
+        }
+
+    with pytest.raises(ValueError):
+        converter.validate(tensors)
+
+
+@pytest.mark.unit
+def test_fp8_block_validate_raises_on_untargeted_scale_inv():
+    """
+    An untargeted module carrying a stray weight_scale_inv must raise ValueError.
+    """
+    converter = FP8BlockDequantizer(
+        targets=[r"re:.*up_proj$"], weight_block_size=(128, 128)
+    )
+
+    with torch.device("meta"):
+        tensors = {
+            "model.layer0.mlp.up_proj.weight": torch.empty(
+                256, 256, dtype=torch.float8_e4m3fn
+            ),
+            "model.layer0.mlp.up_proj.weight_scale_inv": torch.empty(
+                2, 2, dtype=torch.float32
+            ),
+            # untargeted module carrying a stray weight_scale_inv
+            "model.layer0.mlp.down_proj.weight_scale_inv": torch.empty(
+                2, 2, dtype=torch.float32
+            ),
+        }
+
+    with pytest.raises(ValueError):
+        converter.validate(tensors)

--- a/tests/test_entrypoints/convert/converters/test_modelopt_nvfp4.py
+++ b/tests/test_entrypoints/convert/converters/test_modelopt_nvfp4.py
@@ -185,3 +185,32 @@ def test_modelopt_nvfp4_update_config_merges():
     assert merged is existing  # in-place mutation
     assert len(merged.config_groups) == 2  # prior_group + config_group_0
     assert "prior_group" in merged.config_groups
+
+
+@pytest.mark.unit
+def test_modelopt_nvfp4_validate_raises_on_untargeted_qparam():
+    """
+    An untargeted module carrying a quantization param that should only appear on
+    targeted modules must raise ValueError. Regression for validation dropped in
+    the multi-converter refactor (#805).
+    """
+    converter = ModelOptNvfp4Converter(targets=[r"re:.*up_proj$"])
+
+    with torch.device("meta"):
+        tensors = {
+            "model.layer0.mlp.up_proj.input_scale": torch.empty(1, dtype=torch.float32),
+            "model.layer0.mlp.up_proj.weight": torch.empty(256, 256, dtype=torch.uint8),
+            "model.layer0.mlp.up_proj.weight_scale": torch.empty(
+                256, 1, dtype=torch.float8_e4m3fn
+            ),
+            "model.layer0.mlp.up_proj.weight_scale_2": torch.empty(
+                1, dtype=torch.float32
+            ),
+            # untargeted module carrying a disallowed qparam
+            "model.layer0.mlp.down_proj.weight_scale": torch.empty(
+                256, 1, dtype=torch.float8_e4m3fn
+            ),
+        }
+
+    with pytest.raises(ValueError):
+        converter.validate(tensors)


### PR DESCRIPTION
Addresses nightly build errors in llm-compressor.

#805 collapsed each converter's `validate` into the base default (`return self.process`), which dropped two behaviors:
1. Validation stopped raising on wrong targets and orphan qparams, since `process` silently skips untargeted tensors.
2. Pack-quantized CT dequant crashed on meta, because `decompress` reads `weight_shape` data and the validate pass loads every param on meta with no data.

Changes:
- Restore `validate` on `CompressedTensorsDequantizer`, `ModelOptNvfp4Converter`, and `FP8BlockDequantizer`. Each raises `ValueError` on invalid configs and returns `self.process(tensors)` so chained converters observe the resulting format.
- `PackedQuantizationCompressor.decompress` builds the output weight shape locally on meta instead of reading `weight_shape`. `in_features` is exact from the scale for group and tensor-group, and a packed-width placeholder for channel and tensor, which is safe because the validate pass discards the tensor. The load path is unchanged.
- Tests: meta decompress for group and channel, negative validate tests for nvfp4 and fp8block, and update the CTDequantizer missing-scale test to expect `ValueError`.

Testing: convert converters and pack-quantized suites pass, 180 tests.

Plan to continue: confirm the three llm-compressor nightly-cadence tests go green on the version bump.
