### PR TITLE
[Quantization] Fix decompression dtype

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -112,11 +112,7 @@ class BaseCompressor(RegistryMixin, ABC):
         module.quantization_status = QuantizationStatus.COMPRESSED
 
     @classmethod
-    def decompress_module(
-        cls,
-        module: torch.nn.Module,
-        dtype: Optional[torch.dtype] = None,
-    ) -> None:
+    def decompress_module(cls, module: torch.nn.Module) -> None:
         """
         Decompress a module in-place by decompressing its state dict.
 
@@ -125,16 +121,14 @@ class BaseCompressor(RegistryMixin, ABC):
         version.
 
         :param module: the module to decompress in-place
-        :param dtype: target dtype for the decompressed weight. When provided,
-            the decompressed weight is cast to this dtype to match the model's
-            parameter dtype.
         """
         scheme = getattr(module, "quantization_scheme")
 
         state_dict = get_direct_state_dict(module)
         decompressed_state_dict = cls.decompress(state_dict, scheme)
 
-        if dtype is not None and "weight" in decompressed_state_dict:
+        dtype = torch.get_default_dtype()
+        if "weight" in decompressed_state_dict:
             weight = decompressed_state_dict["weight"]
             if weight.is_floating_point() and weight.dtype != dtype:
                 decompressed_state_dict["weight"] = weight.to(dtype)
@@ -207,9 +201,7 @@ def compress_module(
 
 
 def decompress_module(
-    module: torch.nn.Module,
-    format: Optional[CompressionFormat] = None,
-    dtype: Optional[torch.dtype] = None,
+    module: torch.nn.Module, format: Optional[CompressionFormat] = None
 ):
     """
     Decompress a module which has had quantization applied to it. Sets the
@@ -222,9 +214,6 @@ def decompress_module(
 
     :param module: module to decompress inplace
     :param format: force override for decompression format
-    :param dtype: target dtype for the decompressed weight. When provided,
-        the decompressed weight is cast to this dtype to match the model's
-        parameter dtype.
     """
     scheme = getattr(module, "quantization_scheme", None)
     if not isinstance(scheme, QuantizationScheme):
@@ -234,4 +223,4 @@ def decompress_module(
         format or scheme.format or infer_module_format(type(module), scheme)
     )
     compressor = BaseCompressor.get_value_from_registry(scheme.format.value)
-    compressor.decompress_module(module, dtype=dtype)
+    compressor.decompress_module(module)

--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -77,7 +77,10 @@ class BaseCompressor(RegistryMixin, ABC):
 
     @classmethod
     def decompress(
-        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+        cls,
+        state_dict: TensorStateDict,
+        scheme: QuantizationScheme,
+        dtype: Optional[torch.dtype] = None,
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict. Does not modify the input.
@@ -86,6 +89,8 @@ class BaseCompressor(RegistryMixin, ABC):
 
         :param state_dict: compressed per-module state dict with local parameter names
         :param scheme: quantization scheme containing quantization parameters
+        :param dtype: target dtype for decompressed weights. If None, defaults to
+            ``torch.get_default_dtype()``
         :return: decompressed per-module state dict
         """
         raise NotImplementedError(
@@ -112,7 +117,9 @@ class BaseCompressor(RegistryMixin, ABC):
         module.quantization_status = QuantizationStatus.COMPRESSED
 
     @classmethod
-    def decompress_module(cls, module: torch.nn.Module) -> None:
+    def decompress_module(
+        cls, module: torch.nn.Module, dtype: Optional[torch.dtype] = None
+    ) -> None:
         """
         Decompress a module in-place by decompressing its state dict.
 
@@ -121,11 +128,13 @@ class BaseCompressor(RegistryMixin, ABC):
         version.
 
         :param module: the module to decompress in-place
+        :param dtype: target dtype for decompressed weights. If None, defaults to
+            ``torch.get_default_dtype()``
         """
         scheme = getattr(module, "quantization_scheme")
 
         state_dict = get_direct_state_dict(module)
-        decompressed_state_dict = cls.decompress(state_dict, scheme)
+        decompressed_state_dict = cls.decompress(state_dict, scheme, dtype=dtype)
         replace_direct_state_dict(module, decompressed_state_dict)
 
         module.quantization_status = QuantizationStatus.DECOMPRESSED
@@ -194,7 +203,9 @@ def compress_module(
 
 
 def decompress_module(
-    module: torch.nn.Module, format: Optional[CompressionFormat] = None
+    module: torch.nn.Module,
+    format: Optional[CompressionFormat] = None,
+    dtype: Optional[torch.dtype] = None,
 ):
     """
     Decompress a module which has had quantization applied to it. Sets the
@@ -207,6 +218,8 @@ def decompress_module(
 
     :param module: module to decompress inplace
     :param format: force override for decompression format
+    :param dtype: target dtype for decompressed weights. If None, defaults to
+        ``torch.get_default_dtype()``
     """
     scheme = getattr(module, "quantization_scheme", None)
     if not isinstance(scheme, QuantizationScheme):
@@ -216,4 +229,4 @@ def decompress_module(
         format or scheme.format or infer_module_format(type(module), scheme)
     )
     compressor = BaseCompressor.get_value_from_registry(scheme.format.value)
-    compressor.decompress_module(module)
+    compressor.decompress_module(module, dtype=dtype)

--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -112,7 +112,11 @@ class BaseCompressor(RegistryMixin, ABC):
         module.quantization_status = QuantizationStatus.COMPRESSED
 
     @classmethod
-    def decompress_module(cls, module: torch.nn.Module) -> None:
+    def decompress_module(
+        cls,
+        module: torch.nn.Module,
+        dtype: Optional[torch.dtype] = None,
+    ) -> None:
         """
         Decompress a module in-place by decompressing its state dict.
 
@@ -121,11 +125,20 @@ class BaseCompressor(RegistryMixin, ABC):
         version.
 
         :param module: the module to decompress in-place
+        :param dtype: target dtype for the decompressed weight. When provided,
+            the decompressed weight is cast to this dtype to match the model's
+            parameter dtype.
         """
         scheme = getattr(module, "quantization_scheme")
 
         state_dict = get_direct_state_dict(module)
         decompressed_state_dict = cls.decompress(state_dict, scheme)
+
+        if dtype is not None and "weight" in decompressed_state_dict:
+            weight = decompressed_state_dict["weight"]
+            if weight.is_floating_point() and weight.dtype != dtype:
+                decompressed_state_dict["weight"] = weight.to(dtype)
+
         replace_direct_state_dict(module, decompressed_state_dict)
 
         module.quantization_status = QuantizationStatus.DECOMPRESSED
@@ -194,7 +207,9 @@ def compress_module(
 
 
 def decompress_module(
-    module: torch.nn.Module, format: Optional[CompressionFormat] = None
+    module: torch.nn.Module,
+    format: Optional[CompressionFormat] = None,
+    dtype: Optional[torch.dtype] = None,
 ):
     """
     Decompress a module which has had quantization applied to it. Sets the
@@ -207,6 +222,9 @@ def decompress_module(
 
     :param module: module to decompress inplace
     :param format: force override for decompression format
+    :param dtype: target dtype for the decompressed weight. When provided,
+        the decompressed weight is cast to this dtype to match the model's
+        parameter dtype.
     """
     scheme = getattr(module, "quantization_scheme", None)
     if not isinstance(scheme, QuantizationScheme):
@@ -216,4 +234,4 @@ def decompress_module(
         format or scheme.format or infer_module_format(type(module), scheme)
     )
     compressor = BaseCompressor.get_value_from_registry(scheme.format.value)
-    compressor.decompress_module(module)
+    compressor.decompress_module(module, dtype=dtype)

--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -126,13 +126,6 @@ class BaseCompressor(RegistryMixin, ABC):
 
         state_dict = get_direct_state_dict(module)
         decompressed_state_dict = cls.decompress(state_dict, scheme)
-
-        dtype = torch.get_default_dtype()
-        if "weight" in decompressed_state_dict:
-            weight = decompressed_state_dict["weight"]
-            if weight.is_floating_point() and weight.dtype != dtype:
-                decompressed_state_dict["weight"] = weight.to(dtype)
-
         replace_direct_state_dict(module, decompressed_state_dict)
 
         module.quantization_status = QuantizationStatus.DECOMPRESSED

--- a/src/compressed_tensors/compressors/dense/base.py
+++ b/src/compressed_tensors/compressors/dense/base.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Optional
+
+import torch
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import QuantizationScheme
@@ -41,7 +44,10 @@ class DenseCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+        cls,
+        state_dict: TensorStateDict,
+        scheme: QuantizationScheme,
+        dtype: Optional[torch.dtype] = None,
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -50,6 +56,7 @@ class DenseCompressor(BaseCompressor):
 
         :param state_dict: local-name state dict (weight, ...)
         :param scheme: quantization scheme (unused)
+        :param dtype: target dtype (unused for dense models)
         :return: unmodified state dict
         """
         return state_dict

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -189,7 +189,7 @@ class ModelCompressor:
         ]
 
         # TODO: support distributed decompression
-        dtype = getattr(model, "dtype", None)
+        dtype = torch.get_default_dtype()
         for module in tqdm(modules, desc=desc):
             decompress_module(module, self.force_compression_format, dtype=dtype)
 

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -189,9 +189,8 @@ class ModelCompressor:
         ]
 
         # TODO: support distributed decompression
-        dtype = torch.get_default_dtype()
         for module in tqdm(modules, desc=desc):
-            decompress_module(module, self.force_compression_format, dtype=dtype)
+            decompress_module(module, self.force_compression_format)
 
         # update config status to reflect decompression
         if self.quantization_config is not None:

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -189,8 +189,9 @@ class ModelCompressor:
         ]
 
         # TODO: support distributed decompression
+        dtype = getattr(model, "dtype", None)
         for module in tqdm(modules, desc=desc):
-            decompress_module(module, self.force_compression_format)
+            decompress_module(module, self.force_compression_format, dtype=dtype)
 
         # update config status to reflect decompression
         if self.quantization_config is not None:

--- a/src/compressed_tensors/compressors/mxfp8/base.py
+++ b/src/compressed_tensors/compressors/mxfp8/base.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Optional
+
 import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
@@ -71,7 +73,10 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
 
     @classmethod
     def decompress(
-        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+        cls,
+        state_dict: TensorStateDict,
+        scheme: QuantizationScheme,
+        dtype: Optional[torch.dtype] = None,
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict for MXFP8 format.
@@ -81,6 +86,8 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
 
         :param state_dict: local-name state dict (weight, weight_scale, ...)
         :param scheme: quantization scheme for the weight
+        :param dtype: target dtype for decompressed weights. If None, defaults to
+            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -89,7 +96,7 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
         scale = state_dict["weight_scale"]
         state_dict["weight_scale"] = cls._decompress_scale(scale)
 
-        return NaiveQuantizationCompressor.decompress(state_dict, scheme)
+        return NaiveQuantizationCompressor.decompress(state_dict, scheme, dtype=dtype)
 
     @classmethod
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:

--- a/src/compressed_tensors/compressors/mxfp8/base.py
+++ b/src/compressed_tensors/compressors/mxfp8/base.py
@@ -46,8 +46,8 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
         return compress_mx_scale(scale, scale_dtype)
 
     @classmethod
-    def _decompress_scale(cls, scale: torch.Tensor) -> torch.Tensor:
-        return decompress_mx_scale(scale)
+    def _decompress_scale(cls, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+        return decompress_mx_scale(scale).to(dtype)
 
     @classmethod
     def compress(
@@ -92,9 +92,11 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
         """
         state_dict = state_dict.copy()
 
-        # Convert E8M0 scale back to bfloat16 for consistency with model dtype
+        dtype = dtype or torch.get_default_dtype()
+
+        # Convert E8M0 scale back to target dtype for consistency with model dtype
         scale = state_dict["weight_scale"]
-        state_dict["weight_scale"] = cls._decompress_scale(scale)
+        state_dict["weight_scale"] = cls._decompress_scale(scale, dtype)
 
         return NaiveQuantizationCompressor.decompress(state_dict, scheme, dtype=dtype)
 

--- a/src/compressed_tensors/compressors/naive_quantized/base.py
+++ b/src/compressed_tensors/compressors/naive_quantized/base.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
     BaseCompressor,
@@ -116,11 +117,13 @@ class NaiveQuantizationCompressor(BaseCompressor):
         zero_point = state_dict.get("weight_zero_point", None)
         g_idx = state_dict.get("weight_g_idx", None)
 
+        dtype = torch.get_default_dtype()
         state_dict["weight"] = dequantize(
             x_q=weight,
             scale=scale,
             zero_point=zero_point,
             g_idx=g_idx,
+            dtype=dtype,
         )
 
         return state_dict

--- a/src/compressed_tensors/compressors/naive_quantized/base.py
+++ b/src/compressed_tensors/compressors/naive_quantized/base.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Optional
+
 import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
@@ -99,7 +101,10 @@ class NaiveQuantizationCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+        cls,
+        state_dict: TensorStateDict,
+        scheme: QuantizationScheme,
+        dtype: Optional[torch.dtype] = None,
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -109,6 +114,8 @@ class NaiveQuantizationCompressor(BaseCompressor):
 
         :param state_dict: local-name state dict (weight, weight_scale, …)
         :param scheme: quantization scheme for the weight
+        :param dtype: target dtype for decompressed weights. If None, defaults to
+            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -117,7 +124,7 @@ class NaiveQuantizationCompressor(BaseCompressor):
         zero_point = state_dict.get("weight_zero_point", None)
         g_idx = state_dict.get("weight_g_idx", None)
 
-        dtype = torch.get_default_dtype()
+        dtype = dtype or torch.get_default_dtype()
         state_dict["weight"] = dequantize(
             x_q=weight,
             scale=scale,

--- a/src/compressed_tensors/compressors/nvfp4/base.py
+++ b/src/compressed_tensors/compressors/nvfp4/base.py
@@ -115,11 +115,12 @@ class NVFP4PackedCompressor(BaseCompressor):
 
         scale_float = cls._decompress_scale(scale, unpacked.dtype)
 
+        dtype = torch.get_default_dtype()
         state_dict["weight"] = dequantize(
             x_q=unpacked,
             scale=scale_float,
             global_scale=global_scale,
-            dtype=unpacked.dtype,
+            dtype=dtype,
         )
         state_dict["weight_scale"] = torch.nn.Parameter(
             scale_float, requires_grad=False

--- a/src/compressed_tensors/compressors/nvfp4/base.py
+++ b/src/compressed_tensors/compressors/nvfp4/base.py
@@ -117,12 +117,13 @@ class NVFP4PackedCompressor(BaseCompressor):
         scale = state_dict.get("weight_scale")
         global_scale = state_dict.get("weight_global_scale", None)
 
-        m, n = packed.shape
-        unpacked = unpack_fp4_from_uint8(packed, m, n * 2)
-
-        scale_float = cls._decompress_scale(scale, unpacked.dtype)
-
         dtype = dtype or torch.get_default_dtype()
+
+        m, n = packed.shape
+        unpacked = unpack_fp4_from_uint8(packed, m, n * 2, dtype=dtype)
+
+        scale_float = cls._decompress_scale(scale, dtype)
+
         state_dict["weight"] = dequantize(
             x_q=unpacked,
             scale=scale_float,

--- a/src/compressed_tensors/compressors/nvfp4/base.py
+++ b/src/compressed_tensors/compressors/nvfp4/base.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Optional
+
 import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
@@ -93,7 +95,10 @@ class NVFP4PackedCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+        cls,
+        state_dict: TensorStateDict,
+        scheme: QuantizationScheme,
+        dtype: Optional[torch.dtype] = None,
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -103,6 +108,8 @@ class NVFP4PackedCompressor(BaseCompressor):
 
         :param state_dict: local-name state dict (weight_packed, weight_scale, …)
         :param scheme: quantization scheme for the weight
+        :param dtype: target dtype for decompressed weights. If None, defaults to
+            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -115,7 +122,7 @@ class NVFP4PackedCompressor(BaseCompressor):
 
         scale_float = cls._decompress_scale(scale, unpacked.dtype)
 
-        dtype = torch.get_default_dtype()
+        dtype = dtype or torch.get_default_dtype()
         state_dict["weight"] = dequantize(
             x_q=unpacked,
             scale=scale_float,

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
+from typing import Optional
 
 import torch
 from compressed_tensors.compressors.base import (
@@ -116,7 +117,10 @@ class PackedQuantizationCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
+        cls,
+        state_dict: TensorStateDict,
+        scheme: QuantizationScheme,
+        dtype: Optional[torch.dtype] = None,
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -125,7 +129,9 @@ class PackedQuantizationCompressor(BaseCompressor):
         ``weight_packed``, and unpacks the zero-point if present.
 
         :param state_dict: local-name state dict (weight_packed, weight_scale, …)
-        :param quantization_args: quantization parameters for the weight
+        :param scheme: quantization scheme for the weight
+        :param dtype: target dtype for decompressed weights. If None, defaults to
+            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -136,7 +142,7 @@ class PackedQuantizationCompressor(BaseCompressor):
         original_shape = state_dict.get("weight_shape")
         weights = scheme.weights
 
-        dtype = torch.get_default_dtype()
+        dtype = dtype or torch.get_default_dtype()
 
         if packed.device.type == "meta":
             # Build the dequantized weight shape locally instead of reading

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -136,6 +136,8 @@ class PackedQuantizationCompressor(BaseCompressor):
         original_shape = state_dict.get("weight_shape")
         weights = scheme.weights
 
+        dtype = torch.get_default_dtype()
+
         if packed.device.type == "meta":
             # Build the dequantized weight shape locally instead of reading
             # weight_shape, which arrives on meta (no data) in the validate
@@ -161,7 +163,7 @@ class PackedQuantizationCompressor(BaseCompressor):
                 in_features = packed.shape[-1] * 32 // weights.num_bits
             state_dict["weight"] = torch.empty(
                 (*packed.shape[:-1], in_features),
-                dtype=scale.dtype,
+                dtype=dtype,
                 device="meta",
             )
             return state_dict
@@ -181,6 +183,7 @@ class PackedQuantizationCompressor(BaseCompressor):
             scale=scale,
             zero_point=zero_point,
             g_idx=g_idx,
+            dtype=dtype,
         )
 
         return state_dict

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -22,7 +22,6 @@ from compressed_tensors.utils.safetensors_load import (
 )
 from loguru import logger
 from transformers.file_utils import CONFIG_NAME
-from transformers.modeling_utils import local_torch_dtype
 
 
 class CompressedTensorsDequantizer(Converter):
@@ -111,32 +110,33 @@ class CompressedTensorsDequantizer(Converter):
         """
         dequantized_tensors = {}
 
-        with local_torch_dtype(self.dtype):
-            for scheme in self.quant_config.config_groups.values():
-                compressor = BaseCompressor.get_value_from_registry(scheme.format)
-                param_names = compressor.compression_param_names(scheme)
-                for module_name, tensor_name in match_quantizable_tensors(
-                    tensors,
-                    ignore=self.quant_config.ignore,
-                    targets=scheme.targets,
-                    param_targets=[param_names[0]],
-                ):
-                    # Create state dict of param_name -> torch.Tensor
-                    state_dict = {
-                        f"{param_name}": tensors.pop(f"{module_name}.{param_name}")
-                        for param_name in param_names
-                    }
+        for scheme in self.quant_config.config_groups.values():
+            compressor = BaseCompressor.get_value_from_registry(scheme.format)
+            param_names = compressor.compression_param_names(scheme)
+            for module_name, tensor_name in match_quantizable_tensors(
+                tensors,
+                ignore=self.quant_config.ignore,
+                targets=scheme.targets,
+                param_targets=[param_names[0]],
+            ):
+                # Create state dict of param_name -> torch.Tensor
+                state_dict = {
+                    f"{param_name}": tensors.pop(f"{module_name}.{param_name}")
+                    for param_name in param_names
+                }
 
-                    dequantized_state_dict = compressor.decompress(state_dict, scheme)
+                dequantized_state_dict = compressor.decompress(
+                    state_dict, scheme, dtype=self.dtype
+                )
 
-                    # Add only weight param to dequantized tensors
-                    weight = dequantized_state_dict["weight"]
-                    dequantized_tensors[f"{module_name}.weight"] = weight
-                    if weight.dtype != self.dtype:
-                        logger.warning(
-                            f"{module_name} decompressed dtype ({weight.dtype}) "
-                            f"does not match model dtype ({self.dtype})"
-                        )
+                # Add only weight param to dequantized tensors
+                weight = dequantized_state_dict["weight"]
+                dequantized_tensors[f"{module_name}.weight"] = weight
+                if weight.dtype != self.dtype:
+                    logger.warning(
+                        f"{module_name} decompressed dtype ({weight.dtype}) "
+                        f"does not match model dtype ({self.dtype})"
+                    )
 
         # Copy over any remaining ignored/untargeted tensors, skipping kv cache qparams
         kv_cache_param_names = [v.value for v in KVCacheScaleType]

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -20,6 +20,7 @@ from compressed_tensors.utils.safetensors_load import (
     get_checkpoint_files,
     get_quantization_config,
 )
+from loguru import logger
 from transformers.file_utils import CONFIG_NAME
 from transformers.modeling_utils import local_torch_dtype
 
@@ -126,14 +127,16 @@ class CompressedTensorsDequantizer(Converter):
                         for param_name in param_names
                     }
 
-                    dequantized_state_dict = compressor.decompress(
-                        state_dict, scheme
-                    )
+                    dequantized_state_dict = compressor.decompress(state_dict, scheme)
 
                     # Add only weight param to dequantized tensors
-                    dequantized_tensors[f"{module_name}.weight"] = (
-                        dequantized_state_dict["weight"].to(self.dtype)
-                    )
+                    weight = dequantized_state_dict["weight"]
+                    dequantized_tensors[f"{module_name}.weight"] = weight
+                    if weight.dtype != self.dtype:
+                        logger.warning(
+                            f"{module_name} decompressed dtype ({weight.dtype}) "
+                            f"does not match model dtype ({self.dtype})"
+                        )
 
         # Copy over any remaining ignored/untargeted tensors, skipping kv cache qparams
         kv_cache_param_names = [v.value for v in KVCacheScaleType]

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 import os
-from typing import Iterable
+from typing import Iterable, Optional
 
 import pydantic
 import torch
@@ -20,6 +21,7 @@ from compressed_tensors.utils.safetensors_load import (
     get_quantization_config,
 )
 from transformers.file_utils import CONFIG_NAME
+from transformers.modeling_utils import local_torch_dtype
 
 
 class CompressedTensorsDequantizer(Converter):
@@ -32,10 +34,8 @@ class CompressedTensorsDequantizer(Converter):
         self,
         model_stub: str | os.PathLike,
         ignore: Iterable[str] = tuple(),
-        dtype=torch.bfloat16,
+        dtype: Optional[torch.dtype] = None,
     ):
-        self.dtype = dtype
-
         # load quantization config from model_stub
         model_files = get_checkpoint_files(model_stub)
         if CONFIG_NAME in model_files:
@@ -44,6 +44,13 @@ class CompressedTensorsDequantizer(Converter):
             config_resolved_path = model_files["params.json"]
         else:
             raise ValueError("Could not find config.json file")
+
+        if dtype is None:
+            with open(config_resolved_path, "r") as f:
+                config = json.load(f)
+            dtype_str = config.get("dtype", config.get("torch_dtype", "bfloat16"))
+            dtype = getattr(torch, dtype_str)
+        self.dtype = dtype
 
         quant_config_data = get_quantization_config(config_resolved_path)
         if quant_config_data is None:
@@ -103,27 +110,30 @@ class CompressedTensorsDequantizer(Converter):
         """
         dequantized_tensors = {}
 
-        for scheme in self.quant_config.config_groups.values():
-            compressor = BaseCompressor.get_value_from_registry(scheme.format)
-            param_names = compressor.compression_param_names(scheme)
-            for module_name, tensor_name in match_quantizable_tensors(
-                tensors,
-                ignore=self.quant_config.ignore,
-                targets=scheme.targets,
-                param_targets=[param_names[0]],
-            ):
-                # Create state dict of param_name -> torch.Tensor
-                state_dict = {
-                    f"{param_name}": tensors.pop(f"{module_name}.{param_name}")
-                    for param_name in param_names
-                }
+        with local_torch_dtype(self.dtype):
+            for scheme in self.quant_config.config_groups.values():
+                compressor = BaseCompressor.get_value_from_registry(scheme.format)
+                param_names = compressor.compression_param_names(scheme)
+                for module_name, tensor_name in match_quantizable_tensors(
+                    tensors,
+                    ignore=self.quant_config.ignore,
+                    targets=scheme.targets,
+                    param_targets=[param_names[0]],
+                ):
+                    # Create state dict of param_name -> torch.Tensor
+                    state_dict = {
+                        f"{param_name}": tensors.pop(f"{module_name}.{param_name}")
+                        for param_name in param_names
+                    }
 
-                dequantized_state_dict = compressor.decompress(state_dict, scheme)
+                    dequantized_state_dict = compressor.decompress(
+                        state_dict, scheme
+                    )
 
-                # Add only weight param to dequantized tensors
-                dequantized_tensors[f"{module_name}.weight"] = dequantized_state_dict[
-                    "weight"
-                ].to(self.dtype)
+                    # Add only weight param to dequantized tensors
+                    dequantized_tensors[f"{module_name}.weight"] = (
+                        dequantized_state_dict["weight"].to(self.dtype)
+                    )
 
         # Copy over any remaining ignored/untargeted tensors, skipping kv cache qparams
         kv_cache_param_names = [v.value for v in KVCacheScaleType]

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -55,6 +55,7 @@ def _apply_quantize_op(
             x_q=x,
             scale=scale,
             zero_point=zero_point,
+            dtype=dtype,
             global_scale=global_scale,
         )
 

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -168,3 +168,35 @@ def test_linear_only_config_leaves_embedding_untouched():
     assert embed_keys == {"weight"}
     assert not hasattr(model.embed, "quantization_status")
     assert torch.equal(model.embed.weight, embed_weight_before)
+
+
+@requires_gpu
+@pytest.mark.parametrize(
+    "scheme_name,expected_format",
+    [
+        ("NVFP4A16", CompressionFormat.nvfp4_pack_quantized),
+        ("MXFP4A16", CompressionFormat.mxfp4_pack_quantized),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_decompress_module_respects_target_dtype(scheme_name, expected_format, dtype):
+    """
+    decompress_module should cast the decompressed weight to the target dtype
+    when one is provided. Without this, FP4 decompression always returns
+    bfloat16 (hardcoded in unpack_fp4_from_uint8), causing dtype mismatches
+    when the model runs in a different dtype (e.g. float32).
+    """
+    module = nn.Linear(256, 256, bias=False).to(dtype=torch.bfloat16, device="cuda")
+    scheme = preset_name_to_scheme(scheme_name, ["Linear"])
+    initialize_module_for_quantization(module, scheme)
+
+    with torch.no_grad():
+        module.weight.fill_(1)
+
+    compress_module(module)
+    decompress_module(module, dtype=dtype)
+
+    weight = get_direct_state_dict(module)["weight"]
+    assert weight.dtype == dtype, (
+        f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"
+    )

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -203,6 +203,6 @@ def test_decompress_module_respects_default_dtype(scheme_name, dtype):
     weight = get_direct_state_dict(module)["weight"]
     fp4_schemes = {"NVFP4A16", "NVFP4", "MXFP4A16", "MXFP4"}
     if scheme_name in fp4_schemes:
-        assert weight.dtype == dtype, (
-            f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"
-        )
+        assert (
+            weight.dtype == dtype
+        ), f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -16,9 +16,11 @@ from compressed_tensors.quantization import (
     initialize_module_for_quantization,
     preset_name_to_scheme,
 )
+from compressed_tensors.quantization.quant_scheme import PRESET_SCHEMES
 from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import get_direct_state_dict
 from tests.testing_utils import requires_gpu
+from transformers.modeling_utils import local_torch_dtype
 
 
 @requires_gpu
@@ -55,13 +57,9 @@ def _run_compress_decompress(
 
     # 3. Decompress the module and verify shapes and dtypes are restored.
     # Set default dtype to bfloat16 to match the module dtype, since
-    # decompress_module casts weights to torch.get_default_dtype().
-    prev_dtype = torch.get_default_dtype()
-    try:
-        torch.set_default_dtype(torch.bfloat16)
+    # NVFP4/MXFP4 decompression uses torch.get_default_dtype().
+    with local_torch_dtype(torch.bfloat16):
         decompress_module(module)
-    finally:
-        torch.set_default_dtype(prev_dtype)
 
     post_state_dict = get_direct_state_dict(module)
     for name, tensor in post_state_dict.items():
@@ -178,20 +176,17 @@ def test_linear_only_config_leaves_embedding_untouched():
 
 
 @requires_gpu
-@pytest.mark.parametrize(
-    "scheme_name,expected_format",
-    [
-        ("NVFP4A16", CompressionFormat.nvfp4_pack_quantized),
-        ("MXFP4A16", CompressionFormat.mxfp4_pack_quantized),
-    ],
-)
+@pytest.mark.parametrize("scheme_name", list(PRESET_SCHEMES.keys()))
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-def test_decompress_module_respects_default_dtype(scheme_name, expected_format, dtype):
+def test_decompress_module_respects_default_dtype(scheme_name, dtype):
     """
-    decompress_module should cast the decompressed weight to match
-    torch.get_default_dtype(). Without this, FP4 decompression always returns
-    bfloat16 (hardcoded in unpack_fp4_from_uint8), causing dtype mismatches
-    when the model runs in a different dtype (e.g. float32).
+    FP4 decompression (NVFP4/MXFP4) should produce weights matching
+    torch.get_default_dtype(). Without this, unpack_fp4_from_uint8 always
+    returns bfloat16, causing dtype mismatches when the model runs in a
+    different dtype (e.g. float32).
+
+    All other schemes are included to verify they don't break under a
+    non-default dtype context.
     """
     module = nn.Linear(256, 256, bias=False).to(dtype=torch.bfloat16, device="cuda")
     scheme = preset_name_to_scheme(scheme_name, ["Linear"])
@@ -202,14 +197,12 @@ def test_decompress_module_respects_default_dtype(scheme_name, expected_format, 
 
     compress_module(module)
 
-    prev_dtype = torch.get_default_dtype()
-    try:
-        torch.set_default_dtype(dtype)
+    with local_torch_dtype(dtype):
         decompress_module(module)
-    finally:
-        torch.set_default_dtype(prev_dtype)
 
     weight = get_direct_state_dict(module)["weight"]
-    assert weight.dtype == dtype, (
-        f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"
-    )
+    fp4_schemes = {"NVFP4A16", "NVFP4", "MXFP4A16", "MXFP4"}
+    if scheme_name in fp4_schemes:
+        assert weight.dtype == dtype, (
+            f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"
+        )

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -180,13 +180,13 @@ def test_linear_only_config_leaves_embedding_untouched():
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 def test_decompress_module_respects_default_dtype(scheme_name, dtype):
     """
-    FP4 decompression (NVFP4/MXFP4) should produce weights matching
-    torch.get_default_dtype(). Without this, unpack_fp4_from_uint8 always
-    returns bfloat16, causing dtype mismatches when the model runs in a
-    different dtype (e.g. float32).
+    Decompression should produce weights matching torch.get_default_dtype(),
+    regardless of the quantization scheme. Without this, some compressors
+    (e.g. FP4 via unpack_fp4_from_uint8, or MXFP8 via decompress_mx_scale)
+    hardcode bfloat16, causing dtype mismatches when the model runs in a
+    different dtype.
 
-    All other schemes are included to verify they don't break under a
-    non-default dtype context.
+    UNQUANTIZED is excluded because DenseCompressor is a no-op.
     """
     module = nn.Linear(256, 256, bias=False).to(dtype=torch.bfloat16, device="cuda")
     scheme = preset_name_to_scheme(scheme_name, ["Linear"])
@@ -201,8 +201,7 @@ def test_decompress_module_respects_default_dtype(scheme_name, dtype):
         decompress_module(module)
 
     weight = get_direct_state_dict(module)["weight"]
-    fp4_schemes = {"NVFP4A16", "NVFP4", "MXFP4A16", "MXFP4"}
-    if scheme_name in fp4_schemes:
+    if scheme_name != "UNQUANTIZED":
         assert (
             weight.dtype == dtype
         ), f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -54,7 +54,14 @@ def _run_compress_decompress(
     assert module.quantization_scheme.format == expected_format
 
     # 3. Decompress the module and verify shapes and dtypes are restored.
-    decompress_module(module)
+    # Set default dtype to bfloat16 to match the module dtype, since
+    # decompress_module casts weights to torch.get_default_dtype().
+    prev_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.bfloat16)
+        decompress_module(module)
+    finally:
+        torch.set_default_dtype(prev_dtype)
 
     post_state_dict = get_direct_state_dict(module)
     for name, tensor in post_state_dict.items():
@@ -179,10 +186,10 @@ def test_linear_only_config_leaves_embedding_untouched():
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-def test_decompress_module_respects_target_dtype(scheme_name, expected_format, dtype):
+def test_decompress_module_respects_default_dtype(scheme_name, expected_format, dtype):
     """
-    decompress_module should cast the decompressed weight to the target dtype
-    when one is provided. Without this, FP4 decompression always returns
+    decompress_module should cast the decompressed weight to match
+    torch.get_default_dtype(). Without this, FP4 decompression always returns
     bfloat16 (hardcoded in unpack_fp4_from_uint8), causing dtype mismatches
     when the model runs in a different dtype (e.g. float32).
     """
@@ -194,7 +201,13 @@ def test_decompress_module_respects_target_dtype(scheme_name, expected_format, d
         module.weight.fill_(1)
 
     compress_module(module)
-    decompress_module(module, dtype=dtype)
+
+    prev_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(dtype)
+        decompress_module(module)
+    finally:
+        torch.set_default_dtype(prev_dtype)
 
     weight = get_direct_state_dict(module)["weight"]
     assert weight.dtype == dtype, (


### PR DESCRIPTION
## Purpose ##
* Fix decompression dtype for nvfp4 models
  * Previously, weights would always decompress to bfloat16, which is not correct for some (mostly testing) models
* Better defaulting of the dtype argument for ct decompressor

## Changes ##
* Cast to torch local dtype when decompressing weights
  * This will be a no-op in most cases when the model dtype is already bfloat16
* In ct decompressor, read default dtype from config

## Testing ##

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
from llmcompressor.utils import load_context

model_id = "/data/kylesayrs/hub/GLM-5.2-0.8B-A0.8B-MXFP4xMXFP8"
with load_context():
    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto")
tokenizer = AutoTokenizer.from_pretrained(model_id)

input_ids = tokenizer("According to all known laws", return_tensors="pt").input_ids.to(model.device)
output = model.generate(input_ids, max_new_tokens=20)
print(tokenizer.decode(output[0]))
```