### PR TITLE
Fix dtype mismatch in distributed offload caches

### DIFF
--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -17,7 +17,12 @@ class DistributedCPUCache(CPUCache):
     @catch_cpu_mem_error
     def offload(self, tensor: torch.Tensor | None) -> torch.Tensor | None:
         """
-        Synchronously create shared cpu memory for offload
+        Synchronously create shared cpu memory for offload.
+
+        The dtype of ``tensor`` on non-source ranks cannot be trusted because
+        transformers may initialize buffers (e.g. ``inv_freq``) with a
+        different dtype than the checkpoint value on the source rank. See
+        https://github.com/huggingface/transformers/pull/47486
 
         :param tensor: tensor on any device
         :return: cpu tensor whose data is located in shared memory
@@ -32,25 +37,28 @@ class DistributedCPUCache(CPUCache):
             # create shared memory cpu tensor
             tensor = super().offload(tensor).share_memory_()
             handle, filename, nbytes = tensor.untyped_storage()._share_filename_cpu_()
-            broadcast_obj = [handle, filename, nbytes]
+            broadcast_obj = [handle, filename, nbytes, tensor.dtype]
         else:
-            broadcast_obj = [None, None, None]
+            broadcast_obj = [None, None, None, None]
 
         # receive shared memory file handle
         dist.broadcast_object_list(broadcast_obj, src=get_source_rank())
 
         if not is_source_process():
-            # materialize meta tensor only if necessary
-            if tensor.device.type == "meta":
-                tensor = to_empty(tensor, device=self.offload_device)
+            src_dtype = broadcast_obj[3]
+
+            if tensor.device.type == "meta" or tensor.dtype != src_dtype:
+                tensor = to_empty(tensor, device=self.offload_device, dtype=src_dtype)
             else:
                 tensor = send_tensors(tensor, device=self.offload_device)
 
             # reconstruct tensor from shared memory file handle
             with torch.no_grad():
                 tensor.set_(
-                    torch.UntypedStorage._new_shared_filename_cpu(*broadcast_obj),
-                    storage_offset=tensor.storage_offset(),
+                    torch.UntypedStorage._new_shared_filename_cpu(
+                        *broadcast_obj[:3]
+                    ),
+                    storage_offset=0,
                     size=tensor.size(),
                     stride=tensor.stride(),
                 )

--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -56,7 +56,7 @@ class DistributedCPUCache(CPUCache):
             with torch.no_grad():
                 tensor.set_(
                     torch.UntypedStorage._new_shared_filename_cpu(*broadcast_obj),
-                    storage_offset=0,
+                    storage_offset=tensor.storage_offset(),
                     size=tensor.size(),
                     stride=tensor.stride(),
                 )

--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -45,7 +45,7 @@ class DistributedCPUCache(CPUCache):
         dist.broadcast_object_list(broadcast_obj, src=get_source_rank())
 
         if not is_source_process():
-            src_dtype = broadcast_obj[3]
+            src_dtype = broadcast_obj.pop(3)
 
             if tensor.device.type == "meta" or tensor.dtype != src_dtype:
                 tensor = to_empty(tensor, device=self.offload_device, dtype=src_dtype)
@@ -55,9 +55,7 @@ class DistributedCPUCache(CPUCache):
             # reconstruct tensor from shared memory file handle
             with torch.no_grad():
                 tensor.set_(
-                    torch.UntypedStorage._new_shared_filename_cpu(
-                        *broadcast_obj[:3]
-                    ),
+                    torch.UntypedStorage._new_shared_filename_cpu(*broadcast_obj),
                     storage_offset=0,
                     size=tensor.size(),
                     stride=tensor.stride(),

--- a/src/compressed_tensors/offload/cache/dist_disk.py
+++ b/src/compressed_tensors/offload/cache/dist_disk.py
@@ -5,7 +5,7 @@ import torch
 import torch.distributed as dist
 from compressed_tensors.distributed import get_source_rank, is_source_process
 from compressed_tensors.offload.cache.disk import DiskCache
-from compressed_tensors.offload.utils import send_tensors
+from compressed_tensors.offload.utils import send_tensors, to_empty
 
 
 class DistributedDiskCache(DiskCache):
@@ -16,7 +16,12 @@ class DistributedDiskCache(DiskCache):
 
     def offload(self, tensor: torch.Tensor | None) -> torch.Tensor | None:
         """
-        Synchronously write tensor data to disk
+        Synchronously write tensor data to disk.
+
+        The dtype of ``tensor`` on non-source ranks cannot be trusted because
+        transformers may initialize buffers (e.g. ``inv_freq``) with a
+        different dtype than the checkpoint value on the source rank. See
+        https://github.com/huggingface/transformers/pull/47486
 
         :param tensor: tensor on any device
         :return: meta tensor representing disk offloaded parameter
@@ -39,6 +44,9 @@ class DistributedDiskCache(DiskCache):
         dist.broadcast_object_list(broadcast_obj, src=get_source_rank())
 
         if not is_source_process():
+            src_dtype = getattr(torch, broadcast_obj[2])
+            if offloaded.dtype != src_dtype:
+                offloaded = to_empty(offloaded, device="meta", dtype=src_dtype)
             self.index[offloaded] = {
                 "safetensors_file": broadcast_obj[0],
                 "weight_name": broadcast_obj[1],


### PR DESCRIPTION
## Summary
- Broadcast the source dtype from rank 0 and use it when materializing tensors on non-source ranks in `DistributedCPUCache` and `DistributedDiskCache`
- Transformers may initialize buffers (e.g. `inv_freq`) with a different dtype than the checkpoint value on the source rank, causing a storage size mismatch when reconstructing shared memory tensors
- See https://github.com/huggingface/transformers/pull/47486

## Test plan
- [x] Tested with `Gemma4ForConditionalGeneration` (`google/gemma-4-26B-A4B-it`) using `torchrun --nproc_per_node=2` with `device_map="auto_offload"` and `torch_dtype=torch.bfloat16`
- [x] Verified `rotary_emb.full_attention_inv_freq` buffer (shape `[256]`, float32 on meta, bfloat16 in checkpoint) no longer causes `RuntimeError: setStorage` on rank 1
- [x] Tested with `DeepSeek-V4-Flash-BF16` (2-GPU DDP) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)