### PR TITLE
fix: raise on non-finite qparams during pack-quantized compression

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -146,8 +146,8 @@ class ModelCompressor:
         # Collect all quantized modules
         desc = "Compressing model"
         modules = [
-            module
-            for _, module in model.named_modules(remove_duplicate=True)
+            (name, module)
+            for name, module in model.named_modules(remove_duplicate=True)
             if (
                 is_module_quantized(module)
                 and (
@@ -160,11 +160,16 @@ class ModelCompressor:
 
         # Compress modules using distributed or sequential
         if not is_distributed():
-            for module in tqdm(modules, desc=desc):
-                compress_module(module, self.force_compression_format)
+            for name, module in tqdm(modules, desc=desc):
+                try:
+                    compress_module(module, self.force_compression_format)
+                except ValueError as exc:
+                    raise ValueError(f"Error compressing module {name}: {exc}") from exc
         else:
             compress_fn = partial(compress_module, format=self.force_compression_format)
-            replace_module_parallel(modules, compress_fn, desc=desc)
+            replace_module_parallel(
+                [module for _, module in modules], compress_fn, desc=desc
+            )
 
         # update config status to reflect compression
         if self.quantization_config is not None:

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -94,6 +94,18 @@ class PackedQuantizationCompressor(BaseCompressor):
             state_dict = cls._remove_symmetric_zp(state_dict, scheme)
             return state_dict
 
+        for name, value in (("weight_scale", scale), ("weight_zero_point", zero_point)):
+            if value is not None and value.is_floating_point():
+                num_nonfinite = (~value.isfinite()).sum().item()
+                if num_nonfinite > 0:
+                    raise ValueError(
+                        f"{name} contains {num_nonfinite}/{value.numel()} "
+                        "non-finite values and cannot be compressed. This usually "
+                        "means the module was targeted for quantization but never "
+                        "calibrated, leaving its quantization parameters "
+                        "uninitialized"
+                    )
+
         quantized_weight = quantize(
             x=weight,
             scale=scale,

--- a/tests/test_compressors/model_compressors/test_model_compressor.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor.py
@@ -126,6 +126,26 @@ class TestModelCompressorCompression:
         assert model.linear.weight_packed.dtype == torch.int32
         assert hasattr(model, "ct_decompress_hook")
 
+    def test_compress_model_nonfinite_scale_raises(self):
+        """Non-finite scales fail loudly at compress time, naming the module."""
+        model = DummyLinear()
+        scheme = create_quantization_scheme(bits=4, type="int", strategy="channel")
+        model.linear.quantization_scheme = scheme
+        model.linear.quantization_status = QuantizationStatus.FROZEN
+        scale = torch.ones(model.linear.weight.shape[0], 1) * 0.01
+        scale[0] = float("nan")
+        scale[1] = float("inf")
+        model.linear.weight_scale = nn.Parameter(scale)
+        model.linear.weight_zero_point = nn.Parameter(
+            torch.zeros(model.linear.weight.shape[0], 1).int(), requires_grad=False
+        )
+
+        q_config = create_quantization_config(bits=4, format="pack-quantized")
+        compressor = ModelCompressor(quantization_config=q_config)
+
+        with pytest.raises(ValueError, match=r"linear.*weight_scale.*2/10"):
+            compressor.compress_model(model)
+
     def test_compress_model_skips_non_quantized_modules(self):
         """Test that modules without quantization_scheme are skipped."""
         model = TwoLayerModel()


### PR DESCRIPTION
## Summary

Hardening for #832. `initialize_qparams` registers scales with `torch.empty` and nothing zero-fills them, so a module that is targeted for quantization but never written by calibration carries uninitialized memory in `weight_scale`. Compression currently quantizes and packs with those scales without complaint, and the result is hard to spot after the fact: measured on 0.18.0 (CPU), every NaN-scale element quantizes to 0 and packs to the constant word `0x88888888`, while whole-tensor stats of `weight_packed` still look well distributed. Details and isolation matrix in [this comment](https://github.com/vllm-project/compressed-tensors/issues/832#issuecomment-5406233097).

This makes pack-quantized compression fail loudly at compress time instead of serializing garbage.

## Changes

- `PackedQuantizationCompressor.compress` validates `weight_scale` (and `weight_zero_point` when floating point) before quantizing and raises `ValueError` with the non-finite count. The check sits after the meta-device early return, so the distributed meta pass is unaffected.
- `ModelCompressor.compress_model` keeps module names when collecting modules and wraps per-module `ValueError` with the module path, so the error names the offending module.
- Test: non-finite scale on a tiny pack-quantized model raises with module name and count; existing tests cover the finite path unchanged.

## Validation

CPU, torch 2.13.0, Python 3.11:

```
$ pytest tests/test_compressors/test_pack_quant.py tests/test_compressors/model_compressors/test_model_compressor.py -q
150 passed, 2 skipped, 1 warning in 0.98s
```

Full `tests/test_compressors/` failure set is identical to main on this machine (75 pre-existing environment-specific failures, all CUDA/MPS related, zero introduced). `make quality` passes.
