### PR TITLE
perf: memoize calculate_range

### DIFF
--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -3,6 +3,7 @@
 
 import logging
 import math
+from functools import lru_cache
 
 import torch
 from compressed_tensors.quantization.quant_args import (
@@ -195,25 +196,19 @@ def compute_dynamic_scales_and_zp(
     return calculate_qparams(min_val, max_val, args, global_scale=global_scale)
 
 
-def calculate_range(
-    quantization_args: QuantizationArgs, device: str
+@lru_cache(maxsize=None)
+def _calculate_range(
+    quant_type: str, num_bits: int, device: str | torch.device
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Calculated the effective quantization range for the given Quantization Args
-
-    :param quantization_args: quantization args to get range of
-    :param device: device to store the range to
-    :return: tuple endpoints for the given quantization range
-    """
-    if quantization_args.type == QuantizationType.INT:
-        bit_range = 2.0**quantization_args.num_bits
+    if quant_type == QuantizationType.INT:
+        bit_range = 2.0**num_bits
         q_max = torch.tensor(bit_range / 2 - 1, device=device)
         q_min = torch.tensor(-bit_range / 2, device=device)
-    elif quantization_args.type == QuantizationType.FLOAT:
-        if quantization_args.num_bits == 8:
+    elif quant_type == QuantizationType.FLOAT:
+        if num_bits == 8:
             q_max = torch.tensor(FP8_E4M3_DATA.max, device=device)
             q_min = torch.tensor(FP8_E4M3_DATA.min, device=device)
-        elif quantization_args.num_bits == 4:
+        elif num_bits == 4:
             q_max = torch.tensor(FP4_E2M1_DATA.max, device=device)
             q_min = torch.tensor(FP4_E2M1_DATA.min, device=device)
         else:
@@ -221,9 +216,26 @@ def calculate_range(
                 "Range calculation only supported for 4 and 8 bits"
             )
     else:
-        raise ValueError(f"Invalid quantization type {quantization_args.type}")
+        raise ValueError(f"Invalid quantization type {quant_type}")
 
     return q_min, q_max
+
+
+def calculate_range(
+    quantization_args: QuantizationArgs, device: str
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Calculated the effective quantization range for the given Quantization Args
+
+    Results are memoized on (type, num_bits, device), so the scalar tensors are
+    constructed once per unique key instead of on every call. The returned
+    tensors are shared across calls and must not be modified in place.
+
+    :param quantization_args: quantization args to get range of
+    :param device: device to store the range to
+    :return: tuple endpoints for the given quantization range
+    """
+    return _calculate_range(quantization_args.type, quantization_args.num_bits, device)
 
 
 def is_module_quantized(module: Module) -> bool:

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -1159,3 +1159,25 @@ def test_quantize_backends_match(args, x, scale, zero_point, global_scale):
     assert torch.allclose(
         torch_out.float(), triton_out.float(), atol=atol, rtol=rtol
     ), f"Max diff: {(torch_out.float() - triton_out.float()).abs().max().item()}"
+
+
+def test_calculate_range_memoized_on_field_values():
+    """calculate_range is memoized on (type, num_bits, device), not on
+    QuantizationArgs identity, so equal args constructed separately share
+    one cached result."""
+    device = torch.device("cpu")
+    args_a = QuantizationArgs(num_bits=4, type="int", symmetric=True)
+    args_b = QuantizationArgs(num_bits=4, type="int", symmetric=True)
+
+    q_min_a, q_max_a = calculate_range(args_a, device)
+    q_min_b, q_max_b = calculate_range(args_b, device)
+
+    assert q_min_a is q_min_b
+    assert q_max_a is q_max_b
+    assert q_min_a.item() == -8.0
+    assert q_max_a.item() == 7.0
+
+    # distinct field values map to distinct cache entries
+    q_min_8, q_max_8 = calculate_range(QuantizationArgs(num_bits=8, type="int"), device)
+    assert q_min_8.item() == -128.0
+    assert q_max_8.item() == 127.0


### PR DESCRIPTION
## Summary

Item 1 of the attack order proposed in [this #766 comment](https://github.com/vllm-project/compressed-tensors/issues/766#issuecomment-5406315144). `calculate_range` constructs two scalar tensors on every call. `_process_quantization` calls it on every quantize/dequantize, and under GPTQ W4A16 that is once per weight column: 245,760 calls for Qwen2.5-0.5B. On CUDA each `torch.tensor(scalar, device=cuda)` is a synchronous H2D copy, so that path pays two blocking copies per column. The range depends only on `(type, num_bits, device)`, so cache it.

## Changes

- `calculate_range` body moves to `_calculate_range(quant_type, num_bits, device)` under `lru_cache(maxsize=None)`. The public wrapper keeps the exact signature and passes field values, not the `QuantizationArgs` instance, so memoization is correct across recreated and mutated pydantic instances (GPTQ creates a fresh `copy(quant_args)` per column).
- Cached tensors are shared across calls. All consumers use them read-only (subtraction, clamp bounds, triton `tl.load`); docstring now states the contract.
- Test: equal args constructed separately share one cached result; distinct `(type, num_bits)` keys give distinct correct ranges.

## Validation

CPU, torch 2.13.0, Python 3.11.

Bit-identical outputs: a fixed-seed loop of 48 `fake_quantize` calls covering W4A16 group-128, channel-strategy column vectors (the GPTQ inner-loop shape), and FP8 tensor strategy, run on main and on this branch:

```
bit-identical across all 48 tensors: True
```

Call-count collapse, cProfile around 1000 `fake_quantize` calls (W4A16 group-128, one warmup call excluded):

```
before:
  1000  0.001  0.005  helpers.py:198(calculate_range)
  2000  0.004  0.004  {built-in method torch.tensor}
after:
  1000  0.001  0.001  helpers.py:224(calculate_range)
  (no torch.tensor calls; range constructed once at warmup)
```

On CPU the tensor constructions are ~4 us/call, so wall clock is unchanged; the expected win is on CUDA where the two constructions are synchronous H2D copies (measurements in the linked comment). GPU validation with torch.profiler is pending; happy to run it on request.

```
$ pytest tests/test_quantization/lifecycle/test_forward.py tests/test_quantization/test_utils/ tests/test_quantization/test_quant_args.py -q
4 failed, 127 passed, 66 skipped, 1 warning in 3.50s
```

The 4 failures are pre-existing on main on this machine (fp8 `test_quantize_dequantize_matches_sequential` on MPS) and unrelated. `tests/test_compressors/test_pack_quant.py`, `test_int_quant.py`, `test_fp8_quant.py`: 153 passed. `make quality` passes.
