### PR TITLE
Revert "[Quantization] Fix decompression dtype (#839)"

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -77,10 +77,7 @@ class BaseCompressor(RegistryMixin, ABC):
 
     @classmethod
     def decompress(
-        cls,
-        state_dict: TensorStateDict,
-        scheme: QuantizationScheme,
-        dtype: Optional[torch.dtype] = None,
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict. Does not modify the input.
@@ -89,8 +86,6 @@ class BaseCompressor(RegistryMixin, ABC):
 
         :param state_dict: compressed per-module state dict with local parameter names
         :param scheme: quantization scheme containing quantization parameters
-        :param dtype: target dtype for decompressed weights. If None, defaults to
-            ``torch.get_default_dtype()``
         :return: decompressed per-module state dict
         """
         raise NotImplementedError(
@@ -117,9 +112,7 @@ class BaseCompressor(RegistryMixin, ABC):
         module.quantization_status = QuantizationStatus.COMPRESSED
 
     @classmethod
-    def decompress_module(
-        cls, module: torch.nn.Module, dtype: Optional[torch.dtype] = None
-    ) -> None:
+    def decompress_module(cls, module: torch.nn.Module) -> None:
         """
         Decompress a module in-place by decompressing its state dict.
 
@@ -128,13 +121,11 @@ class BaseCompressor(RegistryMixin, ABC):
         version.
 
         :param module: the module to decompress in-place
-        :param dtype: target dtype for decompressed weights. If None, defaults to
-            ``torch.get_default_dtype()``
         """
         scheme = getattr(module, "quantization_scheme")
 
         state_dict = get_direct_state_dict(module)
-        decompressed_state_dict = cls.decompress(state_dict, scheme, dtype=dtype)
+        decompressed_state_dict = cls.decompress(state_dict, scheme)
         replace_direct_state_dict(module, decompressed_state_dict)
 
         module.quantization_status = QuantizationStatus.DECOMPRESSED
@@ -203,9 +194,7 @@ def compress_module(
 
 
 def decompress_module(
-    module: torch.nn.Module,
-    format: Optional[CompressionFormat] = None,
-    dtype: Optional[torch.dtype] = None,
+    module: torch.nn.Module, format: Optional[CompressionFormat] = None
 ):
     """
     Decompress a module which has had quantization applied to it. Sets the
@@ -218,8 +207,6 @@ def decompress_module(
 
     :param module: module to decompress inplace
     :param format: force override for decompression format
-    :param dtype: target dtype for decompressed weights. If None, defaults to
-        ``torch.get_default_dtype()``
     """
     scheme = getattr(module, "quantization_scheme", None)
     if not isinstance(scheme, QuantizationScheme):
@@ -229,4 +216,4 @@ def decompress_module(
         format or scheme.format or infer_module_format(type(module), scheme)
     )
     compressor = BaseCompressor.get_value_from_registry(scheme.format.value)
-    compressor.decompress_module(module, dtype=dtype)
+    compressor.decompress_module(module)

--- a/src/compressed_tensors/compressors/dense/base.py
+++ b/src/compressed_tensors/compressors/dense/base.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
-import torch
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import QuantizationScheme
@@ -44,10 +41,7 @@ class DenseCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls,
-        state_dict: TensorStateDict,
-        scheme: QuantizationScheme,
-        dtype: Optional[torch.dtype] = None,
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -56,7 +50,6 @@ class DenseCompressor(BaseCompressor):
 
         :param state_dict: local-name state dict (weight, ...)
         :param scheme: quantization scheme (unused)
-        :param dtype: target dtype (unused for dense models)
         :return: unmodified state dict
         """
         return state_dict

--- a/src/compressed_tensors/compressors/mxfp8/base.py
+++ b/src/compressed_tensors/compressors/mxfp8/base.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
 import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
@@ -46,8 +44,8 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
         return compress_mx_scale(scale, scale_dtype)
 
     @classmethod
-    def _decompress_scale(cls, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
-        return decompress_mx_scale(scale).to(dtype)
+    def _decompress_scale(cls, scale: torch.Tensor) -> torch.Tensor:
+        return decompress_mx_scale(scale)
 
     @classmethod
     def compress(
@@ -73,10 +71,7 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
 
     @classmethod
     def decompress(
-        cls,
-        state_dict: TensorStateDict,
-        scheme: QuantizationScheme,
-        dtype: Optional[torch.dtype] = None,
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict for MXFP8 format.
@@ -86,19 +81,15 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
 
         :param state_dict: local-name state dict (weight, weight_scale, ...)
         :param scheme: quantization scheme for the weight
-        :param dtype: target dtype for decompressed weights. If None, defaults to
-            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
 
-        dtype = dtype or torch.get_default_dtype()
-
-        # Convert E8M0 scale back to target dtype for consistency with model dtype
+        # Convert E8M0 scale back to bfloat16 for consistency with model dtype
         scale = state_dict["weight_scale"]
-        state_dict["weight_scale"] = cls._decompress_scale(scale, dtype)
+        state_dict["weight_scale"] = cls._decompress_scale(scale)
 
-        return NaiveQuantizationCompressor.decompress(state_dict, scheme, dtype=dtype)
+        return NaiveQuantizationCompressor.decompress(state_dict, scheme)
 
     @classmethod
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:

--- a/src/compressed_tensors/compressors/naive_quantized/base.py
+++ b/src/compressed_tensors/compressors/naive_quantized/base.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
-import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
     BaseCompressor,
@@ -101,10 +98,7 @@ class NaiveQuantizationCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls,
-        state_dict: TensorStateDict,
-        scheme: QuantizationScheme,
-        dtype: Optional[torch.dtype] = None,
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -114,8 +108,6 @@ class NaiveQuantizationCompressor(BaseCompressor):
 
         :param state_dict: local-name state dict (weight, weight_scale, …)
         :param scheme: quantization scheme for the weight
-        :param dtype: target dtype for decompressed weights. If None, defaults to
-            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -124,13 +116,11 @@ class NaiveQuantizationCompressor(BaseCompressor):
         zero_point = state_dict.get("weight_zero_point", None)
         g_idx = state_dict.get("weight_g_idx", None)
 
-        dtype = dtype or torch.get_default_dtype()
         state_dict["weight"] = dequantize(
             x_q=weight,
             scale=scale,
             zero_point=zero_point,
             g_idx=g_idx,
-            dtype=dtype,
         )
 
         return state_dict

--- a/src/compressed_tensors/compressors/nvfp4/base.py
+++ b/src/compressed_tensors/compressors/nvfp4/base.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
 import torch
 from compressed_tensors.compressors.base import (
     COMPRESSIBLE_MODULE_TYPES,
@@ -95,10 +93,7 @@ class NVFP4PackedCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls,
-        state_dict: TensorStateDict,
-        scheme: QuantizationScheme,
-        dtype: Optional[torch.dtype] = None,
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -108,8 +103,6 @@ class NVFP4PackedCompressor(BaseCompressor):
 
         :param state_dict: local-name state dict (weight_packed, weight_scale, …)
         :param scheme: quantization scheme for the weight
-        :param dtype: target dtype for decompressed weights. If None, defaults to
-            ``torch.get_default_dtype()``
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -117,18 +110,16 @@ class NVFP4PackedCompressor(BaseCompressor):
         scale = state_dict.get("weight_scale")
         global_scale = state_dict.get("weight_global_scale", None)
 
-        dtype = dtype or torch.get_default_dtype()
-
         m, n = packed.shape
-        unpacked = unpack_fp4_from_uint8(packed, m, n * 2, dtype=dtype)
+        unpacked = unpack_fp4_from_uint8(packed, m, n * 2)
 
-        scale_float = cls._decompress_scale(scale, dtype)
+        scale_float = cls._decompress_scale(scale, unpacked.dtype)
 
         state_dict["weight"] = dequantize(
             x_q=unpacked,
             scale=scale_float,
             global_scale=global_scale,
-            dtype=dtype,
+            dtype=unpacked.dtype,
         )
         state_dict["weight_scale"] = torch.nn.Parameter(
             scale_float, requires_grad=False

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
-from typing import Optional
 
 import torch
 from compressed_tensors.compressors.base import (
@@ -117,10 +116,7 @@ class PackedQuantizationCompressor(BaseCompressor):
 
     @classmethod
     def decompress(
-        cls,
-        state_dict: TensorStateDict,
-        scheme: QuantizationScheme,
-        dtype: Optional[torch.dtype] = None,
+        cls, state_dict: TensorStateDict, scheme: QuantizationScheme
     ) -> TensorStateDict:
         """
         Decompress a per-module state dict.
@@ -129,9 +125,7 @@ class PackedQuantizationCompressor(BaseCompressor):
         ``weight_packed``, and unpacks the zero-point if present.
 
         :param state_dict: local-name state dict (weight_packed, weight_scale, …)
-        :param scheme: quantization scheme for the weight
-        :param dtype: target dtype for decompressed weights. If None, defaults to
-            ``torch.get_default_dtype()``
+        :param quantization_args: quantization parameters for the weight
         :return: decompressed state dict with weight in float dtype
         """
         state_dict = state_dict.copy()
@@ -141,8 +135,6 @@ class PackedQuantizationCompressor(BaseCompressor):
         g_idx = state_dict.get("weight_g_idx", None)
         original_shape = state_dict.get("weight_shape")
         weights = scheme.weights
-
-        dtype = dtype or torch.get_default_dtype()
 
         if packed.device.type == "meta":
             # Build the dequantized weight shape locally instead of reading
@@ -169,7 +161,7 @@ class PackedQuantizationCompressor(BaseCompressor):
                 in_features = packed.shape[-1] * 32 // weights.num_bits
             state_dict["weight"] = torch.empty(
                 (*packed.shape[:-1], in_features),
-                dtype=dtype,
+                dtype=scale.dtype,
                 device="meta",
             )
             return state_dict
@@ -189,7 +181,6 @@ class PackedQuantizationCompressor(BaseCompressor):
             scale=scale,
             zero_point=zero_point,
             g_idx=g_idx,
-            dtype=dtype,
         )
 
         return state_dict

--- a/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/ct_dequantizer.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import json
 import os
-from typing import Iterable, Optional
+from typing import Iterable
 
 import pydantic
 import torch
@@ -20,7 +19,6 @@ from compressed_tensors.utils.safetensors_load import (
     get_checkpoint_files,
     get_quantization_config,
 )
-from loguru import logger
 from transformers.file_utils import CONFIG_NAME
 
 
@@ -34,8 +32,10 @@ class CompressedTensorsDequantizer(Converter):
         self,
         model_stub: str | os.PathLike,
         ignore: Iterable[str] = tuple(),
-        dtype: Optional[torch.dtype] = None,
+        dtype=torch.bfloat16,
     ):
+        self.dtype = dtype
+
         # load quantization config from model_stub
         model_files = get_checkpoint_files(model_stub)
         if CONFIG_NAME in model_files:
@@ -44,13 +44,6 @@ class CompressedTensorsDequantizer(Converter):
             config_resolved_path = model_files["params.json"]
         else:
             raise ValueError("Could not find config.json file")
-
-        if dtype is None:
-            with open(config_resolved_path, "r") as f:
-                config = json.load(f)
-            dtype_str = config.get("dtype", config.get("torch_dtype", "bfloat16"))
-            dtype = getattr(torch, dtype_str)
-        self.dtype = dtype
 
         quant_config_data = get_quantization_config(config_resolved_path)
         if quant_config_data is None:
@@ -125,18 +118,12 @@ class CompressedTensorsDequantizer(Converter):
                     for param_name in param_names
                 }
 
-                dequantized_state_dict = compressor.decompress(
-                    state_dict, scheme, dtype=self.dtype
-                )
+                dequantized_state_dict = compressor.decompress(state_dict, scheme)
 
                 # Add only weight param to dequantized tensors
-                weight = dequantized_state_dict["weight"]
-                dequantized_tensors[f"{module_name}.weight"] = weight
-                if weight.dtype != self.dtype:
-                    logger.warning(
-                        f"{module_name} decompressed dtype ({weight.dtype}) "
-                        f"does not match model dtype ({self.dtype})"
-                    )
+                dequantized_tensors[f"{module_name}.weight"] = dequantized_state_dict[
+                    "weight"
+                ].to(self.dtype)
 
         # Copy over any remaining ignored/untargeted tensors, skipping kv cache qparams
         kv_cache_param_names = [v.value for v in KVCacheScaleType]

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -55,7 +55,6 @@ def _apply_quantize_op(
             x_q=x,
             scale=scale,
             zero_point=zero_point,
-            dtype=dtype,
             global_scale=global_scale,
         )
 

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -16,11 +16,9 @@ from compressed_tensors.quantization import (
     initialize_module_for_quantization,
     preset_name_to_scheme,
 )
-from compressed_tensors.quantization.quant_scheme import PRESET_SCHEMES
 from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import get_direct_state_dict
 from tests.testing_utils import requires_gpu
-from transformers.modeling_utils import local_torch_dtype
 
 
 @requires_gpu
@@ -56,10 +54,7 @@ def _run_compress_decompress(
     assert module.quantization_scheme.format == expected_format
 
     # 3. Decompress the module and verify shapes and dtypes are restored.
-    # Set default dtype to bfloat16 to match the module dtype, since
-    # NVFP4/MXFP4 decompression uses torch.get_default_dtype().
-    with local_torch_dtype(torch.bfloat16):
-        decompress_module(module)
+    decompress_module(module)
 
     post_state_dict = get_direct_state_dict(module)
     for name, tensor in post_state_dict.items():
@@ -173,35 +168,3 @@ def test_linear_only_config_leaves_embedding_untouched():
     assert embed_keys == {"weight"}
     assert not hasattr(model.embed, "quantization_status")
     assert torch.equal(model.embed.weight, embed_weight_before)
-
-
-@requires_gpu
-@pytest.mark.parametrize("scheme_name", list(PRESET_SCHEMES.keys()))
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-def test_decompress_module_respects_default_dtype(scheme_name, dtype):
-    """
-    Decompression should produce weights matching torch.get_default_dtype(),
-    regardless of the quantization scheme. Without this, some compressors
-    (e.g. FP4 via unpack_fp4_from_uint8, or MXFP8 via decompress_mx_scale)
-    hardcode bfloat16, causing dtype mismatches when the model runs in a
-    different dtype.
-
-    UNQUANTIZED is excluded because DenseCompressor is a no-op.
-    """
-    module = nn.Linear(256, 256, bias=False).to(dtype=torch.bfloat16, device="cuda")
-    scheme = preset_name_to_scheme(scheme_name, ["Linear"])
-    initialize_module_for_quantization(module, scheme)
-
-    with torch.no_grad():
-        module.weight.fill_(1)
-
-    compress_module(module)
-
-    with local_torch_dtype(dtype):
-        decompress_module(module)
-
-    weight = get_direct_state_dict(module)["weight"]
-    if scheme_name != "UNQUANTIZED":
-        assert (
-            weight.dtype == dtype
-        ), f"Expected decompressed weight dtype {dtype}, got {weight.dtype}"


### PR DESCRIPTION
## Purpose ##
* Fix model decompression
  * The commit created better strategies around handling the decompression dtype. Previously, we would assume that weights should be decompressed to either the scale's dtype, or bfloat16. The latter assumption does not hold for all models.
  *  However, this broke decompression. Ultimately, we need the model's dtype to be passed to `decompress_model`, which requires modifying our CT integration

## Testing ##
* Verified that LC's `tests/llmcompressor/transformers/compression/test_decompress.py` now passes