### PR TITLE
[codex] Select the assigned CUDA device in dynamic scheduler workers

### DIFF
--- a/src/compressed_tensors/entrypoints/convert/memory.py
+++ b/src/compressed_tensors/entrypoints/convert/memory.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from contextlib import nullcontext
 from typing import Any
 
 import torch
@@ -54,6 +55,20 @@ def _pick_device(
     return best
 
 
+def _run_job_on_device(job: Callable[[torch.device], Any], device: torch.device) -> Any:
+    """Run a job with the worker thread's assigned CUDA device selected.
+
+    CUDA current-device state is thread-local. Passing ``cuda:N`` to a job is
+    not enough for kernels that validate pointers against the current device.
+    Keep allocation and kernel launch in the same device context for the full
+    job. Non-CUDA backends retain their existing behavior.
+    """
+
+    context = torch.cuda.device(device) if device.type == "cuda" else nullcontext()
+    with context:
+        return job(device)
+
+
 def exec_jobs_dynamic(
     jobs: list[Callable[[torch.device], Any]],
     devices: list[torch.device],
@@ -101,7 +116,7 @@ def exec_jobs_dynamic(
     if all(d.type == "cpu" for d in devices):
         out = []
         for job in tqdm.tqdm(jobs, desc=desc):
-            out.append(job(devices[0]))
+            out.append(_run_job_on_device(job, devices[0]))
         return out
 
     # Snapshot free VRAM once; all later decisions use accounting only
@@ -122,7 +137,7 @@ def exec_jobs_dynamic(
                     f"Job {i} (~{memory_estimates[i] / 1e9:.2f} GB) "
                     f"exceeds estimated capacity of {device}"
                 )
-            out.append(job(device))
+            out.append(_run_job_on_device(job, device))
         return out
 
     # Multi-worker: main thread schedules, workers execute
@@ -150,7 +165,7 @@ def exec_jobs_dynamic(
                 if dev is None:
                     continue
 
-                fut = pool.submit(jobs[idx], dev)
+                fut = pool.submit(_run_job_on_device, jobs[idx], dev)
                 inflight[fut] = idx
                 fut_device[fut] = dev
                 reserved[dev] += memory_estimates[idx]

--- a/tests/test_entrypoints/convert/test_convert_memory.py
+++ b/tests/test_entrypoints/convert/test_convert_memory.py
@@ -8,6 +8,7 @@ import torch
 from compressed_tensors.entrypoints.convert.memory import (
     _free_bytes,
     _pick_device,
+    _run_job_on_device,
     exec_jobs_dynamic,
 )
 
@@ -54,6 +55,47 @@ def test_pick_respects_reservations():
 def test_pick_skips_cpu_devices():
     cpu = torch.device("cpu")
     assert _pick_device([cpu], 1000, {}, {cpu: 0}) is None
+
+
+# ── worker device context ─────────────────────────────────────────────
+
+
+def test_run_job_selects_assigned_cuda_device():
+    events = []
+
+    class DeviceContext:
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc, traceback):
+            events.append("exit")
+
+    device = torch.device("cuda:3")
+
+    def job(dev):
+        assert events == ["enter"]
+        assert dev == device
+        return "passed"
+
+    with patch(
+        "compressed_tensors.entrypoints.convert.memory.torch.cuda.device",
+        return_value=DeviceContext(),
+    ) as cuda_device:
+        assert _run_job_on_device(job, device) == "passed"
+
+    cuda_device.assert_called_once_with(device)
+    assert events == ["enter", "exit"]
+
+
+def test_run_job_does_not_enter_cuda_context_for_cpu():
+    device = torch.device("cpu")
+
+    with patch(
+        "compressed_tensors.entrypoints.convert.memory.torch.cuda.device"
+    ) as cuda_device:
+        assert _run_job_on_device(lambda dev: dev, device) == device
+
+    cuda_device.assert_not_called()
 
 
 # ── exec_jobs_dynamic: CPU path (no GPU required) ──────────────────────


### PR DESCRIPTION
## What changed

Wrap every dynamically scheduled job in the CUDA context for its assigned device. CPU and non-CUDA jobs retain their existing behavior.

The change is intentionally scoped to `exec_jobs_dynamic` and its unit tests. It does not add or modify networking, process groups, rendezvous, ranks, or remote-worker behavior.

## Root cause

CUDA current-device state is thread-local. The scheduler selected `cuda:N` and passed it into a job, but `ThreadPoolExecutor` workers never entered `torch.cuda.device(cuda:N)`. A worker assigned to `cuda:1` could therefore allocate a tensor on `cuda:1` while launching a Triton kernel with current device `cuda:0`, producing:

```
ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
```

## Impact

This unblocks local multi-GPU model-free conversion when jobs launch device-sensitive CUDA/Triton kernels. Single-device, CPU, and non-CUDA paths preserve their prior scheduling semantics.

## Validation

- `python -m py_compile`: passed
- `ruff format` / `ruff check`: passed
- `git diff --check`: passed
- Existing dynamic scheduler regression suite on the runtime backport: 13 passed
- Exact pre-fix `compressed-tensors` main `memory.py`, two GPUs, FP4 Triton: reproduced the pointer error
- Patched implementation, eight concurrent GPUs (`cuda:0` through `cuda:7`), FP4 Triton: passed; assigned/current/tensor/output devices matched on every worker
- Patched runtime backport, two-GPU 14.89 GB real-shard model-free PTQ gate: one-pass and stacked outputs matched exactly across 1,598 keys with zero protected-tensor mismatches
