### PR TITLE
ci: add pre-commit hooks mirroring make quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,76 @@
+# See https://pre-commit.com for usage.
+# Install the git hooks with: pre-commit install
+# These hooks mirror the checks in `make quality` so issues are caught
+# locally before CI runs them. They run the tools from the active (dev)
+# environment (`pip install -e .[dev]`) so versions and config match CI.
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+default_stages:
+  - pre-commit
+repos:
+  - repo: local
+    hooks:
+      # black/isort/flake8 are scoped to PYCHECKDIRS (src tests) from
+      # `make quality` so pre-commit flags exactly what CI does — e.g. setup.py
+      # is intentionally excluded there and must stay excluded here.
+      #
+      # black from the active (dev) environment; mirrors
+      # `black --target-version py310 --check` from `make quality`.
+      - id: black
+        name: black
+        entry: black --target-version py310
+        language: system
+        types: [python]
+        files: ^(src|tests)/
+      # isort from the active (dev) environment; reads [isort] from setup.cfg.
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        types: [python]
+        files: ^(src|tests)/
+      # flake8 from the active (dev) environment; reads [flake8] from setup.cfg.
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+        files: ^(src|tests)/
+      # Mirrors `python utils/copyright.py quality <globs>` from `make quality`
+      # (PYCHECKGLOBS: src, tests, utils, examples, setup.py). The script globs
+      # each argument, so passing changed files works.
+      - id: copyright
+        name: copyright headers
+        entry: python utils/copyright.py quality
+        language: system
+        types: [python]
+        files: ^(src|tests|utils|examples)/|^setup\.py$
+      # Mirrors `python tools/lint_cuda.py <dirs> --fail-on-issues` from
+      # `make quality` (PYCHECKDIRS: src tests). The script accepts files.
+      - id: lint-cuda
+        name: lint cuda
+        entry: python tools/lint_cuda.py --fail-on-issues
+        language: system
+        types: [python]
+        files: ^(src|tests)/
+        require_serial: true
+      # Append a DCO Signed-off-by trailer if the commit message lacks one,
+      # matching the `git commit -s` requirement for vllm-project repos.
+      - id: signoff-commit
+        name: Sign-off commit
+        entry: bash
+        args:
+          - -c
+          - |
+            trailer="Signed-off-by: $(git config user.name) <$(git config user.email)>"
+            msg_file="$(git rev-parse --git-path COMMIT_EDITMSG)"
+            # -F/-x match the trailer as a literal, complete line so names/emails
+            # containing regex metacharacters (or a line with an extra suffix)
+            # can't be mistaken for an existing sign-off.
+            if ! grep -Fqx -- "$trailer" "$msg_file"; then
+              printf "\n%s\n" "$trailer" >> "$msg_file"
+            fi
+        language: system
+        stages: [commit-msg]
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ cd compressed-tensors
 pip install -e .
 ```
 
+## Development
+
+Install the development dependencies and run the linting, formatting, and type checks:
+
+```bash
+pip install -e .[dev]
+make quality   # check
+make style     # auto-fix
+```
+
+### Pre-commit Hooks
+
+We provide [pre-commit](https://pre-commit.com/) hooks that run the same checks as `make quality` (plus a DCO sign-off hook) before each commit, so problems are caught locally instead of in CI. After installing the `[dev]` dependencies, enable them once per clone:
+
+```bash
+pre-commit install
+```
+
+The hooks then run automatically on `git commit`. To run them against all files on demand:
+
+```bash
+pre-commit run --all-files
+```
+
+To bypass the hooks for a single commit, use `git commit --no-verify`; to skip one hook, prefix the command with `SKIP=<hook-id>` (e.g. `SKIP=flake8`).
+
 ## Getting Started
 
 ### Compressing a Model to MXFP4

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def _setup_install_requires() -> List:
 
 def _setup_extras() -> Dict:
     return {
-        "dev": ["black==22.12.0", "isort==5.8.0", "wheel>=0.36.2", "flake8>=3.8.3", "pytest>=6.0.0", "nbconvert>=7.16.3", "accelerate"],
+        "dev": ["black==22.12.0", "isort==5.8.0", "wheel>=0.36.2", "flake8>=3.8.3", "pre-commit>=4.0.0", "pytest>=6.0.0", "nbconvert>=7.16.3", "accelerate"],
         "accelerate": ["accelerate"]
     }
 


### PR DESCRIPTION
Adds [pre-commit](https://pre-commit.com/) hooks that mirror the checks in `make quality`, so contributors catch issues locally before CI runs them. Modeled on vllm-project/speculators#1044, adapted to this repo's tooling.

## What runs

The hooks mirror `make quality`, each scoped to the same paths that target uses:

- **black** (`--target-version py310`), **isort**, **flake8** — scoped to `PYCHECKDIRS` (`src tests`).
- **copyright** — `utils/copyright.py quality`, scoped to `PYCHECKGLOBS` (`src tests utils examples setup.py`).
- **lint-cuda** — `tools/lint_cuda.py --fail-on-issues`, scoped to `src tests`.
- **signoff-commit** — a `commit-msg` hook that appends a DCO `Signed-off-by` trailer if missing, matching the `git commit -s` requirement.

The formatters/linters run as **local `system` hooks** (rather than pinned remote mirrors) so they use the exact versions from the `[dev]` extra and the config in `setup.cfg`. This also sidesteps a build failure when installing the old `isort==5.8.0` pre-commit mirror. Scoping with `files:` matters here — e.g. `setup.py` is intentionally excluded from black/isort/flake8 in `make quality`, so it stays excluded.

## Also

- Add `pre-commit>=4.0.0` to the `[dev]` extra.
- Document the hooks in a new **Development** section of the README (this repo has no `CONTRIBUTING.md`).

## Usage

```bash
pip install -e .[dev]
pre-commit install
```

> Opened as a draft for review of the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)